### PR TITLE
Support file overwriting upload for drivers/quark

### DIFF
--- a/drivers/quark/util.go
+++ b/drivers/quark/util.go
@@ -93,6 +93,7 @@ func (d *Quark) upPre(file model.FileStreamer, parentId string) (UpPreResp, erro
 		"l_updated_at":    now.UnixMilli(),
 		"pdir_fid":        parentId,
 		"size":            file.GetSize(),
+		"same_path_reuse": true,
 	}
 	var resp UpPreResp
 	_, err := d.request("/file/upload/pre", http.MethodPost, func(req *resty.Request) {


### PR DESCRIPTION
Fix: https://github.com/alist-org/alist/issues/1291

- Parameter `same_path_reuse: true` is being used by the quark cloud drive(MacOS client).
- After setting this parameter, Upload a file with the same name to the same path will rewrite the old one.