### PR TITLE
feat:get real url for mediatrack

### DIFF
--- a/drivers/mediatrack/driver.go
+++ b/drivers/mediatrack/driver.go
@@ -91,7 +91,19 @@ func (d *MediaTrack) Link(ctx context.Context, file model.Obj, args model.LinkAr
 	}
 	token := utils.Json.Get(body, "data", "token").ToString()
 	url = "https://kayn.api.mediatrack.cn/v1/download/redirect?token=" + token
-	return &model.Link{URL: url}, nil
+	res, err := base.NoRedirectClient.R().Get(url)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug(res.String())
+	link := model.Link{
+		URL: url,
+	}
+	log.Debugln("res code: ", res.StatusCode())
+	if res.StatusCode() == 302 {
+		link.URL = res.Header().Get("location")
+	}
+	return &link, nil
 }
 
 func (d *MediaTrack) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {

--- a/drivers/mediatrack/driver.go
+++ b/drivers/mediatrack/driver.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -102,6 +103,8 @@ func (d *MediaTrack) Link(ctx context.Context, file model.Obj, args model.LinkAr
 	log.Debugln("res code: ", res.StatusCode())
 	if res.StatusCode() == 302 {
 		link.URL = res.Header().Get("location")
+		expired := time.Duration(60) * time.Second
+		link.Expiration = &expired
 	}
 	return &link, nil
 }


### PR DESCRIPTION
redirect token 一次有效，点击第二次就抛出了`400`错误。本次提交直接获取302后的真实链接返回前端