### PR TITLE
[Draft] feat:async get raw_url,redirect add Referrer-Policy Header

### DIFF
--- a/drivers/123/driver.go
+++ b/drivers/123/driver.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -117,6 +118,8 @@ func (d *Pan123) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 		log.Debugln("res code: ", res.StatusCode())
 		if res.StatusCode() == 302 {
 			link.URL = res.Header().Get("location")
+			expired := time.Duration(60) * time.Second
+			link.Expiration = &expired
 		}
 		return &link, nil
 	} else {

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -69,7 +70,8 @@ func (d *Yun139) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 	if err != nil {
 		return nil, err
 	}
-	return &model.Link{URL: u}, nil
+	expired := time.Duration(60) * time.Second
+	return &model.Link{URL: u, Expiration: &expired}, nil
 }
 
 func (d *Yun139) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {

--- a/drivers/189/driver.go
+++ b/drivers/189/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -89,6 +90,8 @@ func (d *Cloud189) Link(ctx context.Context, file model.Obj, args model.LinkArgs
 		link.URL = resp.FileDownloadUrl
 	}
 	link.URL = strings.Replace(link.URL, "http://", "https://", 1)
+	expired := time.Duration(60) * time.Second
+	link.Expiration = &expired
 	return &link, nil
 }
 

--- a/drivers/189pc/driver.go
+++ b/drivers/189pc/driver.go
@@ -124,9 +124,10 @@ func (y *Yun189PC) Link(ctx context.Context, file model.Obj, args model.LinkArgs
 	if res.StatusCode() == 302 {
 		downloadUrl.URL = res.Header().Get("location")
 	}
-
-	like := &model.Link{
+	expired := time.Duration(60) * time.Second
+	link := &model.Link{
 		URL: downloadUrl.URL,
+		Expiration: &expired,
 		Header: http.Header{
 			"User-Agent": []string{base.UserAgent},
 		},
@@ -142,7 +143,7 @@ func (y *Yun189PC) Link(ctx context.Context, file model.Obj, args model.LinkArgs
 			}
 		}
 	*/
-	return like, nil
+	return link, nil
 }
 
 func (y *Yun189PC) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {

--- a/drivers/aliyundrive/driver.go
+++ b/drivers/aliyundrive/driver.go
@@ -103,10 +103,12 @@ func (d *AliDrive) Link(ctx context.Context, file model.Obj, args model.LinkArgs
 	if err != nil {
 		return nil, err
 	}
+	expired := time.Duration(60) * time.Second
 	return &model.Link{
 		Header: http.Header{
 			"Referer": []string{"https://www.aliyundrive.com/"},
 		},
+		Expiration: &expired,
 		URL: utils.Json.Get(res, "url").ToString(),
 	}, nil
 }

--- a/drivers/aliyundrive_share/driver.go
+++ b/drivers/aliyundrive_share/driver.go
@@ -137,10 +137,12 @@ func (d *AliyundriveShare) Link(ctx context.Context, file model.Obj, args model.
 	} else {
 		u = utils.Json.Get(res.Body(), "url").ToString()
 	}
+	expired := time.Duration(60) * time.Second
 	return &model.Link{
 		Header: http.Header{
 			"Referer": []string{"https://www.aliyundrive.com/"},
 		},
+		Expiration: &expired,
 		URL: u,
 	}, nil
 }

--- a/drivers/baidu_netdisk/util.go
+++ b/drivers/baidu_netdisk/util.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/errs"
@@ -140,8 +141,10 @@ func (d *BaiduNetdisk) linkOfficial(file model.Obj, args model.LinkArgs) (*model
 	//if res.StatusCode() == 302 {
 	u = res.Header().Get("location")
 	//}
+	expired := time.Duration(60) * time.Second
 	return &model.Link{
 		URL: u,
+		Expiration: &expired,
 		Header: http.Header{
 			"User-Agent": []string{"pan.baidu.com"},
 		},

--- a/drivers/baidu_photo/utils.go
+++ b/drivers/baidu_photo/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/errs"
@@ -366,8 +367,10 @@ func (d *BaiduPhoto) linkFile(ctx context.Context, file model.Obj, args model.Li
 	}
 
 	//exp := 8 * time.Hour
+	expired := time.Duration(60) * time.Second
 	link := &model.Link{
 		URL: downloadUrl.Dlink,
+		Expiration: &expired,
 		Header: http.Header{
 			"User-Agent": []string{headers["User-Agent"]},
 			"Referer":    []string{"https://photo.baidu.com/"},

--- a/drivers/google_drive/driver.go
+++ b/drivers/google_drive/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -57,8 +58,10 @@ func (d *GoogleDrive) List(ctx context.Context, dir model.Obj, args model.ListAr
 
 func (d *GoogleDrive) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	url := fmt.Sprintf("https://www.googleapis.com/drive/v3/files/%s?includeItemsFromAllDrives=true&supportsAllDrives=true", file.GetID())
+	expired := time.Duration(60) * time.Second
 	link := model.Link{
 		URL: url + "&alt=media",
+		Expiration: &expired,
 		Header: http.Header{
 			"Authorization": []string{"Bearer " + d.AccessToken},
 		},

--- a/drivers/google_photo/driver.go
+++ b/drivers/google_photo/driver.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -62,14 +63,16 @@ func (d *GooglePhoto) Link(ctx context.Context, file model.Obj, args model.LinkA
 	if err != nil {
 		return nil, err
 	}
-
+	expired := time.Duration(60) * time.Second
 	if strings.Contains(f.MimeType, "image/") {
 		return &model.Link{
 			URL: f.BaseURL + "=d",
+			Expiration: &expired,
 		}, nil
 	} else if strings.Contains(f.MimeType, "video/") {
 		return &model.Link{
 			URL: f.BaseURL + "=dv",
+			Expiration: &expired,
 		}, nil
 	}
 	return &model.Link{}, nil

--- a/drivers/lanzou/driver.go
+++ b/drivers/lanzou/driver.go
@@ -70,9 +70,10 @@ func (d *LanZou) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 	if err != nil {
 		return nil, err
 	}
-
+	expired := time.Duration(60) * time.Second
 	return &model.Link{
 		URL: fileInfo.Url,
+		Expiration: &expired,
 		Header: http.Header{
 			"User-Agent": []string{base.UserAgent},
 		},

--- a/drivers/onedrive/driver.go
+++ b/drivers/onedrive/driver.go
@@ -3,6 +3,7 @@ package onedrive
 import (
 	"context"
 	"net/http"
+	"time"
 	stdpath "path"
 
 	"github.com/alist-org/alist/v3/drivers/base"
@@ -62,8 +63,10 @@ func (d *Onedrive) Link(ctx context.Context, file model.Obj, args model.LinkArgs
 	if f.File == nil {
 		return nil, errs.NotFile
 	}
+	expired := time.Duration(60) * time.Second
 	return &model.Link{
 		URL: f.Url,
+		Expiration: &expired,
 	}, nil
 }
 

--- a/drivers/pikpak/driver.go
+++ b/drivers/pikpak/driver.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -68,8 +69,10 @@ func (d *PikPak) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 	if err != nil {
 		return nil, err
 	}
+	expired := time.Duration(60) * time.Second
 	link := model.Link{
 		URL: resp.WebContentLink,
+		Expiration: &expired,
 	}
 	if len(resp.Medias) > 0 && resp.Medias[0].Link.Url != "" {
 		log.Debugln("use media link")

--- a/drivers/quark/driver.go
+++ b/drivers/quark/driver.go
@@ -72,8 +72,10 @@ func (d *Quark) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (
 	if err != nil {
 		return nil, err
 	}
+	expired := time.Duration(60) * time.Second
 	return &model.Link{
 		URL: resp.Data[0].DownloadUrl,
+		Expiration: &expired,
 		Header: http.Header{
 			"Cookie":  []string{d.Cookie},
 			"Referer": []string{"https://pan.quark.cn"},

--- a/drivers/teambition/driver.go
+++ b/drivers/teambition/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -55,7 +56,8 @@ func (d *Teambition) Link(ctx context.Context, file model.Obj, args model.LinkAr
 		if res.StatusCode() == 302 {
 			url = res.Header().Get("location")
 		}
-		return &model.Link{URL: url}, nil
+		expired := time.Duration(60) * time.Second
+		return &model.Link{URL: url,Expiration: &expired}, nil
 	}
 	return nil, errors.New("can't convert obj to URL")
 }

--- a/drivers/thunder/driver.go
+++ b/drivers/thunder/driver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -259,8 +260,10 @@ func (xc *XunLeiCommon) Link(ctx context.Context, file model.Obj, args model.Lin
 	if err != nil {
 		return nil, err
 	}
+	expired := time.Duration(60) * time.Second
 	link := &model.Link{
 		URL: lFile.WebContentLink,
+		Expiration: &expired,
 		Header: http.Header{
 			"User-Agent": {xc.DownloadUserAgent},
 		},

--- a/drivers/yandex_disk/driver.go
+++ b/drivers/yandex_disk/driver.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"path"
 	"strconv"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -63,8 +64,10 @@ func (d *YandexDisk) Link(ctx context.Context, file model.Obj, args model.LinkAr
 	if err != nil {
 		return nil, err
 	}
+	expired := time.Duration(60) * time.Second
 	link := model.Link{
 		URL: resp.Href,
+		Expiration: &expired,
 	}
 	return &link, nil
 }

--- a/server/handles/down.go
+++ b/server/handles/down.go
@@ -36,6 +36,7 @@ func Down(c *gin.Context) {
 			common.ErrorResp(c, err, 500)
 			return
 		}
+		c.Header("Referrer-Policy", "no-referrer")
 		c.Redirect(302, link.URL)
 	}
 }

--- a/server/handles/fsread.go
+++ b/server/handles/fsread.go
@@ -285,12 +285,21 @@ func FsGet(c *gin.Context) {
 				rawURL = u.URL()
 			} else {
 				// if storage is not proxy, use raw url by fs.Link
-				link, _, err := fs.Link(c, req.Path, model.LinkArgs{IP: c.ClientIP(), Header: c.Request.Header})
-				if err != nil {
-					common.ErrorResp(c, err, 500)
-					return
+//				link, _, err := fs.Link(c, req.Path, model.LinkArgs{IP: c.ClientIP(), Header: c.Request.Header})
+//				if err != nil {
+//					common.ErrorResp(c, err, 500)
+//					return
+//				}
+//				rawURL = link.URL
+				go func() {
+					fs.Link(c, req.Path, model.LinkArgs{IP: c.ClientIP(), Header: c.Request.Header})
+				}()
+				rawURL = fmt.Sprintf("%s/d%s",
+				common.GetApiUrl(c.Request),
+				utils.EncodePath(req.Path, true))
+				if(isEncrypt(meta, req.Path)){
+					rawURL = fmt.Sprintf("%s?sign=%s", rawURL, sign.Sign(obj.GetName()))
 				}
-				rawURL = link.URL
 			}
 		}
 	}


### PR DESCRIPTION
### 实验性讨论

`raw_url` 先给前台返回 `/d(.*)` 地址，然后异步获取真实的 `raw_url` 并缓存，当用户点击 `下载` 的时候直接返回缓存的地址

`down redirect` 添加一个 `c.Header("Referrer-Policy", "no-referrer")` 头，在阿里云这种验证 `referrer` 的情况下外链可以直接下载，因为302后浏览器会丢弃referrer去访问原始地址
测试：[测试阿里云盘下载](https://disk.fly.dev/d/AliDrive/%E5%85%B1%E4%BA%AB/%E5%9B%BE%E7%89%87/2088_4933/1%20(23).jpg)

并且这样阿里云盘的图片也可以外链啦

---

反面例子
借用一个第三方 alist 阿里云盘链接
测试： [目前版本阿里云盘下载](https://cloud.tianli0.top/d/alibaba/%E5%BD%B1%E8%A7%86/Lycoris_Recoil/12.mp4)
因为携带了 `referrer` 所以会返回 403

---

本套代码已经部署到 https://disk.fly.dev 可以测试一下效果