### PR TITLE
feat(aria2): mark aria2 seeding as complete

### DIFF
--- a/internal/aria2/monitor.go
+++ b/internal/aria2/monitor.go
@@ -105,7 +105,14 @@ func (m *Monitor) Update() (bool, error) {
 		return true, errors.WithMessage(err, "failed to transfer file")
 	case "error":
 		return true, errors.Errorf("failed to download %s, error: %s", m.tsk.ID, info.ErrorMessage)
-	case "active", "waiting", "paused":
+	case "active":
+		m.tsk.SetStatus("aria2: " + info.Status)
+		if info.Seeder == "true" {
+			err := m.Complete()
+			return true, errors.WithMessage(err, "failed to transfer file")
+		}
+		return false, nil
+	case "waiting", "paused":
 		m.tsk.SetStatus("aria2: " + info.Status)
 		return false, nil
 	case "removed":


### PR DESCRIPTION
Currently if using aria2 to download a torrent file, it does not consider seeding + active as completed, so the torrent download task only completes as aria2 stops seeding.

This commit uses seeder property of TaskInfo, and mark tasks with active status and true seeder as complete.