### PR TITLE
fix(sign): sign the raw path

### DIFF
--- a/server/common/sign.go
+++ b/server/common/sign.go
@@ -3,11 +3,12 @@ package common
 import (
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/sign"
+	stdpath "path"
 )
 
-func Sign(obj model.Obj, encrypt bool) string {
+func Sign(obj model.Obj, parent string, encrypt bool) string {
 	if obj.IsDir() || !encrypt {
 		return ""
 	}
-	return sign.Sign(obj.GetName())
+	return sign.Sign(stdpath.Join(parent, obj.GetName()))
 }

--- a/server/handles/down.go
+++ b/server/handles/down.go
@@ -58,7 +58,7 @@ func Proxy(c *gin.Context) {
 				URL := fmt.Sprintf("%s%s?sign=%s",
 					strings.Split(downProxyUrl, "\n")[0],
 					utils.EncodePath(rawPath, true),
-					sign.Sign(filename))
+					sign.Sign(rawPath))
 				c.Redirect(302, URL)
 				return
 			}

--- a/server/handles/fsmanage.go
+++ b/server/handles/fsmanage.go
@@ -203,8 +203,8 @@ func Link(c *gin.Context) {
 		common.SuccessResp(c, model.Link{
 			URL: fmt.Sprintf("%s/p%s?d&sign=%s",
 				common.GetApiUrl(c.Request),
-				utils.EncodePath(req.Path, true),
-				sign.Sign(stdpath.Base(rawPath))),
+				utils.EncodePath(rawPath, true),
+				sign.Sign(rawPath)),
 		})
 		return
 	}

--- a/server/middlewares/down.go
+++ b/server/middlewares/down.go
@@ -1,7 +1,6 @@
 package middlewares
 
 import (
-	stdpath "path"
 	"strings"
 
 	"github.com/alist-org/alist/v3/internal/db"
@@ -17,7 +16,6 @@ import (
 func Down(c *gin.Context) {
 	rawPath := parsePath(c.Param("path"))
 	c.Set("path", rawPath)
-	filename := stdpath.Base(rawPath)
 	meta, err := db.GetNearestMeta(rawPath)
 	if err != nil {
 		if !errors.Is(errors.Cause(err), errs.MetaNotFound) {
@@ -29,7 +27,7 @@ func Down(c *gin.Context) {
 	// verify sign
 	if needSign(meta, rawPath) {
 		s := c.Query("sign")
-		err = sign.Verify(filename, strings.TrimSuffix(s, "/"))
+		err = sign.Verify(rawPath, strings.TrimSuffix(s, "/"))
 		if err != nil {
 			common.ErrorResp(c, err, 401)
 			c.Abort()

--- a/server/webdav/webdav.go
+++ b/server/webdav/webdav.go
@@ -231,7 +231,7 @@ func (h *Handler) handleGetHeadPost(w http.ResponseWriter, r *http.Request) (sta
 		u := fmt.Sprintf("%s/p%s?sign=%s",
 			common.GetApiUrl(r),
 			utils.EncodePath(reqPath, true),
-			sign.Sign(path.Base(reqPath)))
+			sign.Sign(reqPath))
 		w.Header().Set("Cache-Control", "max-age=0, no-cache, no-store, must-revalidate")
 		http.Redirect(w, r, u, 302)
 	} else {


### PR DESCRIPTION
For now, we only sign the filename and timestamp to generate a download link. But this may cause a security problem that someone can bypass authentication to access file in other protected storage.

For example, we have two local storages protected with different password:

- /s1
  - f1.txt
- /s2
  - f1.txt

The two files that have the same names (content may differ) but in different storages. Let `/s1` be the root directory of user `u1` and copy the download link of `f1.txt`. The link is working with a suffix `/d/s1/f1.txt?sign=xxxxx`. Now we change `s1` to `s2` in the link, the file `f1.txt` in `s2` is successfully downloaded.

If we sign the whole file path, we can identify this path hack as invalid signature.
