### PR TITLE
优化 webdav 后端

### DIFF
--- a/drivers/webdav/driver.go
+++ b/drivers/webdav/driver.go
@@ -88,6 +88,7 @@ func (d *WebDav) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 	link := &model.Link{Data: reader}
 	if header.Get("Content-Range") != "" {
 		link.Status = 206
+		header.Del("set-cookie")
 		link.Header = header
 	}
 	return link, nil


### PR DESCRIPTION
- [x] 删除使用 sharepoint webdav 后端时，用户请求部分文件时，相应请求头中的 `set-cookie`