### PR TITLE
优化 webdav 后端

### DIFF
--- a/drivers/webdav/driver.go
+++ b/drivers/webdav/driver.go
@@ -86,10 +86,10 @@ func (d *WebDav) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 		return nil, err
 	}
 	link := &model.Link{Data: reader}
+	header.Del("set-cookie")
+	link.Header = header
 	if header.Get("Content-Range") != "" {
 		link.Status = 206
-		header.Del("set-cookie")
-		link.Header = header
 	}
 	return link, nil
 }

--- a/drivers/webdav/driver.go
+++ b/drivers/webdav/driver.go
@@ -73,25 +73,14 @@ func (d *WebDav) List(ctx context.Context, dir model.Obj, args model.ListArgs) (
 //}
 
 func (d *WebDav) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
-	callback := func(r *http.Request) {
-		if args.Header.Get("Range") != "" {
-			r.Header.Set("Range", args.Header.Get("Range"))
-		}
-		if args.Header.Get("If-Range") != "" {
-			r.Header.Set("If-Range", args.Header.Get("If-Range"))
-		}
-	}
-	reader, header, err := d.client.ReadStream(file.GetPath(), callback)
+	url, header, err := d.client.Link(file.GetPath())
 	if err != nil {
 		return nil, err
 	}
-	link := &model.Link{Data: reader}
-	header.Del("set-cookie")
-	link.Header = header
-	if header.Get("Content-Range") != "" {
-		link.Status = 206
-	}
-	return link, nil
+	return &model.Link{
+		URL:    url,
+		Header: header,
+	}, nil
 }
 
 func (d *WebDav) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {

--- a/drivers/webdav/driver.go
+++ b/drivers/webdav/driver.go
@@ -88,6 +88,7 @@ func (d *WebDav) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 	link := &model.Link{Data: reader}
 	if header.Get("Content-Range") != "" {
 		link.Status = 206
+		header.Del("set-cookie")
 		link.Header = header
 	}
 	return link, nil

--- a/drivers/webdav/meta.go
+++ b/drivers/webdav/meta.go
@@ -16,7 +16,7 @@ type Addition struct {
 var config = driver.Config{
 	Name:        "WebDav",
 	LocalSort:   true,
-	OnlyLocal:   true,
+	OnlyProxy:   true,
 	DefaultRoot: "/",
 }
 

--- a/pkg/gowebdav/client.go
+++ b/pkg/gowebdav/client.go
@@ -342,6 +342,58 @@ func (c *Client) Read(path string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func (c *Client) Link(path string) (string, http.Header, error) {
+	method := "HEAD"
+	url := PathEscape(Join(c.root, path))
+	r, err := http.NewRequest(method, url, nil)
+
+	if err != nil {
+		return "", nil, newPathErrorErr("Link", path, err)
+	}
+
+	for k, vals := range c.headers {
+		for _, v := range vals {
+			r.Header.Add(k, v)
+		}
+	}
+
+	c.authMutex.Lock()
+	auth := c.auth
+	c.authMutex.Unlock()
+
+	auth.Authorize(r, method, path)
+
+	if c.interceptor != nil {
+		c.interceptor(method, r)
+	}
+
+	rs, err := c.c.Do(r)
+	if err != nil {
+		return "", nil, newPathErrorErr("Link", path, err)
+	}
+
+	if rs.StatusCode == 401 {
+		wwwAuthenticateHeader := strings.ToLower(rs.Header.Get("Www-Authenticate"))
+		if strings.Contains(wwwAuthenticateHeader, "digest") {
+			c.authMutex.Lock()
+			c.auth = &DigestAuth{auth.User(), auth.Pass(), digestParts(rs)}
+			c.auth.Authorize(r, method, path)
+			c.authMutex.Unlock()
+		} else if strings.Contains(wwwAuthenticateHeader, "basic") {
+			c.authMutex.Lock()
+			c.auth = &BasicAuth{auth.User(), auth.Pass()}
+			c.auth.Authorize(r, method, path)
+			c.authMutex.Unlock()
+		} else {
+			return "", nil, newPathError("Authorize", c.root, rs.StatusCode)
+		}
+	} else if rs.StatusCode > 400 {
+		return "", nil, newPathError("Authorize", path, rs.StatusCode)
+	}
+
+	return r.URL.String(), r.Header, nil
+}
+
 // ReadStream reads the stream for a given path
 func (c *Client) ReadStream(path string, callback func(rq *http.Request)) (io.ReadCloser, http.Header, error) {
 	rs, err := c.req("GET", path, nil, callback)

--- a/server/common/proxy.go
+++ b/server/common/proxy.go
@@ -28,6 +28,8 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.
 		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`, file.GetName(), url.QueryEscape(file.GetName())))
 		w.Header().Set("Content-Length", strconv.FormatInt(file.GetSize(), 10))
 		if link.Header != nil {
+			// TODO clean header with blacklist or whitelist
+			link.Header.Del("set-cookie")
 			for h, val := range link.Header {
 				w.Header()[h] = val
 			}
@@ -81,6 +83,8 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.
 			_ = res.Body.Close()
 		}()
 		log.Debugf("proxy status: %d", res.StatusCode)
+		// TODO clean header with blacklist or whitelist
+		res.Header.Del("set-cookie")
 		for h, v := range res.Header {
 			w.Header()[h] = v
 		}


### PR DESCRIPTION
- [x] 删除使用 sharepoint webdav 后端时，用户请求部分文件时，响应请求头中的 `set-cookie`.
- [x] 减少用户使用 webdav 访问，且目标文件开启了代理 url 时的 302 次数.
- [x]  使 webdav 后端开启代理 url 时用户访问文件不再经过 alist 服务器.

对于第二个：
    
    现在: https://alist.example.com/dav/file --302--> https://alist.example.com/p/file --302--> https://alist-proxy.example.com/file
    期望: https://alist.example.com/dav/file --302--> https://alist-proxy.example.com/file

对于第三个：

    现在: 用户 <--> alist-proxy server <--> alist server <--> webdav server 
    期望: 用户 <--> alist-proxy server <--> webdav server 

