### PR TITLE
fix: fix hide check to canAccess

### DIFF
--- a/server/common/check.go
+++ b/server/common/check.go
@@ -17,7 +17,7 @@ func CanWrite(meta *model.Meta, path string) bool {
 
 func CanAccess(user *model.User, meta *model.Meta, reqPath string, password string) bool {
 	// if the reqPath is in hide (only can check the nearest meta) and user can't see hides, can't access
-	if meta != nil && !user.CanSeeHides() {
+	if meta != nil && !user.CanSeeHides() && meta.Hide != "" {
 		for _, hide := range strings.Split(meta.Hide, "\n") {
 			re := regexp.MustCompile(hide)
 			if re.MatchString(reqPath[len(meta.Path):]) {


### PR DESCRIPTION
修复 meta.Password 和 meta.Hide 都为空的情况下，会导致无权限访问