### PR TITLE
feat: partial update index (#2593)

### DIFF
--- a/internal/search/build.go
+++ b/internal/search/build.go
@@ -143,6 +143,10 @@ func BuildIndex(ctx context.Context, indexPaths, ignorePaths []string, maxDepth 
 	return nil
 }
 
+func Del(ctx context.Context, prefix string) error {
+	return instance.Del(ctx, prefix)
+}
+
 func Clear(ctx context.Context) error {
 	return instance.Clear(ctx)
 }


### PR DESCRIPTION
Maybe we need to lock during the process of `search.Clear` and `search.Del` with `Running.CompareAndSwap`, just `Running.Load` is not enough.