### PR TITLE
重构程序内部路径处理以及文件对象名称映射

### DIFF
--- a/drivers/123/driver.go
+++ b/drivers/123/driver.go
@@ -58,11 +58,6 @@ func (d *Pan123) List(ctx context.Context, dir model.Obj, args model.ListArgs) (
 	})
 }
 
-//func (d *Pan123) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *Pan123) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	if f, ok := file.(File); ok {
 		//var resp DownResp

--- a/drivers/123/types.go
+++ b/drivers/123/types.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/alist-org/alist/v3/internal/model"
-	"github.com/alist-org/alist/v3/pkg/utils"
 )
 
 //type BaseResp struct {
@@ -40,7 +39,7 @@ func (f File) GetSize() int64 {
 }
 
 func (f File) GetName() string {
-	return utils.MappingName(f.FileName)
+	return f.FileName
 }
 
 func (f File) ModTime() time.Time {

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -53,11 +53,6 @@ func (d *Yun139) List(ctx context.Context, dir model.Obj, args model.ListArgs) (
 	}
 }
 
-//func (d *Yun139) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *Yun139) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	u, err := d.getLink(file.GetID())
 	if err != nil {

--- a/drivers/189/driver.go
+++ b/drivers/189/driver.go
@@ -46,11 +46,6 @@ func (d *Cloud189) List(ctx context.Context, dir model.Obj, args model.ListArgs)
 	return d.getFiles(dir.GetID())
 }
 
-//func (d *Cloud189) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *Cloud189) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	var resp DownResp
 	u := "https://cloud.189.cn/api/portal/getFileInfo.action"

--- a/drivers/189pc/types.go
+++ b/drivers/189pc/types.go
@@ -6,8 +6,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-
-	"github.com/alist-org/alist/v3/pkg/utils"
 )
 
 // 居然有四种返回方式
@@ -136,7 +134,7 @@ type Cloud189File struct {
 }
 
 func (c *Cloud189File) GetSize() int64  { return c.Size }
-func (c *Cloud189File) GetName() string { return utils.MappingName(c.Name) }
+func (c *Cloud189File) GetName() string { return c.Name }
 func (c *Cloud189File) ModTime() time.Time {
 	if c.parseTime == nil {
 		c.parseTime = MustParseTime(c.LastOpTime)
@@ -168,7 +166,7 @@ type Cloud189Folder struct {
 }
 
 func (c *Cloud189Folder) GetSize() int64  { return 0 }
-func (c *Cloud189Folder) GetName() string { return utils.MappingName(c.Name) }
+func (c *Cloud189Folder) GetName() string { return c.Name }
 func (c *Cloud189Folder) ModTime() time.Time {
 	if c.parseTime == nil {
 		c.parseTime = MustParseTime(c.LastOpTime)

--- a/drivers/alist_v2/driver.go
+++ b/drivers/alist_v2/driver.go
@@ -67,11 +67,6 @@ func (d *AListV2) List(ctx context.Context, dir model.Obj, args model.ListArgs) 
 	return files, nil
 }
 
-//func (d *AList) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *AListV2) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	url := d.Address + "/api/public/path"
 	var resp common.Resp[PathResp]

--- a/drivers/alist_v3/driver.go
+++ b/drivers/alist_v3/driver.go
@@ -71,11 +71,6 @@ func (d *AListV3) List(ctx context.Context, dir model.Obj, args model.ListArgs) 
 	return files, nil
 }
 
-//func (d *AList) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *AListV3) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	url := d.Address + "/api/fs/get"
 	var resp common.Resp[FsGetResp]

--- a/drivers/aliyundrive/driver.go
+++ b/drivers/aliyundrive/driver.go
@@ -81,11 +81,6 @@ func (d *AliDrive) List(ctx context.Context, dir model.Obj, args model.ListArgs)
 	})
 }
 
-//func (d *AliDrive) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// TODO this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *AliDrive) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	data := base.Json{
 		"drive_id":   d.DriveId,

--- a/drivers/aliyundrive_share/driver.go
+++ b/drivers/aliyundrive_share/driver.go
@@ -68,11 +68,6 @@ func (d *AliyundriveShare) List(ctx context.Context, dir model.Obj, args model.L
 	})
 }
 
-//func (d *AliyundriveShare) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *AliyundriveShare) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	data := base.Json{
 		"drive_id": d.DriveId,

--- a/drivers/baidu_netdisk/driver.go
+++ b/drivers/baidu_netdisk/driver.go
@@ -52,11 +52,6 @@ func (d *BaiduNetdisk) List(ctx context.Context, dir model.Obj, args model.ListA
 	})
 }
 
-//func (d *BaiduNetdisk) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *BaiduNetdisk) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	if d.DownloadAPI == "crack" {
 		return d.linkCrack(file, args)

--- a/drivers/baidu_photo/types.go
+++ b/drivers/baidu_photo/types.go
@@ -3,8 +3,6 @@ package baiduphoto
 import (
 	"fmt"
 	"time"
-
-	"github.com/alist-org/alist/v3/pkg/utils"
 )
 
 type TokenErrResp struct {
@@ -102,7 +100,7 @@ type (
 )
 
 func (a *Album) GetSize() int64  { return 0 }
-func (a *Album) GetName() string { return utils.MappingName(a.Title) }
+func (a *Album) GetName() string { return a.Title }
 func (a *Album) ModTime() time.Time {
 	if a.parseTime == nil {
 		a.parseTime = toTime(a.Mtime)

--- a/drivers/ftp/driver.go
+++ b/drivers/ftp/driver.go
@@ -60,11 +60,6 @@ func (d *FTP) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]m
 	return res, nil
 }
 
-//func (d *FTP) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *FTP) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	if err := d.login(); err != nil {
 		return nil, err

--- a/drivers/google_drive/driver.go
+++ b/drivers/google_drive/driver.go
@@ -112,7 +112,7 @@ func (d *GoogleDrive) Remove(ctx context.Context, obj model.Obj) error {
 }
 
 func (d *GoogleDrive) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) error {
-	obj, _ := op.Get(ctx, d, stdpath.Join(dstDir.GetPath(), stream.GetName()))
+	obj, _ := op.GetUnwrap(ctx, d, stdpath.Join(dstDir.GetPath(), stream.GetName()))
 
 	var (
 		e    Error

--- a/drivers/google_drive/driver.go
+++ b/drivers/google_drive/driver.go
@@ -51,11 +51,6 @@ func (d *GoogleDrive) List(ctx context.Context, dir model.Obj, args model.ListAr
 	})
 }
 
-//func (d *GoogleDrive) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *GoogleDrive) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	url := fmt.Sprintf("https://www.googleapis.com/drive/v3/files/%s?includeItemsFromAllDrives=true&supportsAllDrives=true", file.GetID())
 	_, err := d.request(url, http.MethodGet, nil, nil)

--- a/drivers/google_drive/driver.go
+++ b/drivers/google_drive/driver.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	stdpath "path"
 	"strconv"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
-	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/go-resty/resty/v2"
 )
@@ -112,8 +110,7 @@ func (d *GoogleDrive) Remove(ctx context.Context, obj model.Obj) error {
 }
 
 func (d *GoogleDrive) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) error {
-	obj, _ := op.GetUnwrap(ctx, d, stdpath.Join(dstDir.GetPath(), stream.GetName()))
-
+	obj := stream.GetOld()
 	var (
 		e    Error
 		url  string

--- a/drivers/google_photo/driver.go
+++ b/drivers/google_photo/driver.go
@@ -47,11 +47,6 @@ func (d *GooglePhoto) List(ctx context.Context, dir model.Obj, args model.ListAr
 	})
 }
 
-//func (d *GooglePhoto) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *GooglePhoto) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	f, err := d.getMedia(file.GetID())
 	if err != nil {

--- a/drivers/mediatrack/driver.go
+++ b/drivers/mediatrack/driver.go
@@ -146,7 +146,7 @@ func (d *MediaTrack) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
 }
 
 func (d *MediaTrack) Remove(ctx context.Context, obj model.Obj) error {
-	dir, err := op.Get(ctx, d, path.Dir(obj.GetPath()))
+	dir, err := op.GetUnwrap(ctx, d, path.Dir(obj.GetPath()))
 	if err != nil {
 		return err
 	}

--- a/drivers/mediatrack/driver.go
+++ b/drivers/mediatrack/driver.go
@@ -8,14 +8,12 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
 	"strconv"
 	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/model"
-	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -59,7 +57,7 @@ func (d *MediaTrack) List(ctx context.Context, dir model.Obj, args model.ListArg
 		if f.File != nil && f.File.Cover != "" {
 			thumb = "https://nano.mtres.cn/" + f.File.Cover
 		}
-		return &model.ObjThumb{
+		return &Object{
 			Object: model.Object{
 				ID:       f.ID,
 				Name:     f.Title,
@@ -68,6 +66,7 @@ func (d *MediaTrack) List(ctx context.Context, dir model.Obj, args model.ListArg
 				Size:     size,
 			},
 			Thumbnail: model.Thumbnail{Thumbnail: thumb},
+			ParentID:  dir.GetID(),
 		}, nil
 	})
 }
@@ -146,16 +145,18 @@ func (d *MediaTrack) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
 }
 
 func (d *MediaTrack) Remove(ctx context.Context, obj model.Obj) error {
-	dir, err := op.GetUnwrap(ctx, d, path.Dir(obj.GetPath()))
-	if err != nil {
-		return err
+	var parentID string
+	if o, ok := obj.(*Object); ok {
+		parentID = o.ParentID
+	} else {
+		return fmt.Errorf("obj is not local Object")
 	}
 	data := base.Json{
-		"origin_id": dir.GetID(),
+		"origin_id": parentID,
 		"ids":       []string{obj.GetID()},
 	}
 	url := "https://jayce.api.mediatrack.cn/v4/assets/batch/delete"
-	_, err = d.request(url, http.MethodDelete, func(req *resty.Request) {
+	_, err := d.request(url, http.MethodDelete, func(req *resty.Request) {
 		req.SetBody(data)
 	}, nil)
 	return err

--- a/drivers/mediatrack/driver.go
+++ b/drivers/mediatrack/driver.go
@@ -72,11 +72,6 @@ func (d *MediaTrack) List(ctx context.Context, dir model.Obj, args model.ListArg
 	})
 }
 
-//func (d *MediaTrack) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *MediaTrack) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	url := fmt.Sprintf("https://kayn.api.mediatrack.cn/v1/download_token/asset?asset_id=%s&source_type=project&password=&source_id=%s",
 		file.GetID(), d.ProjectID)

--- a/drivers/mediatrack/types.go
+++ b/drivers/mediatrack/types.go
@@ -1,6 +1,10 @@
 package mediatrack
 
-import "time"
+import (
+	"time"
+
+	"github.com/alist-org/alist/v3/internal/model"
+)
 
 type BaseResp struct {
 	Status  string `json:"status"`
@@ -59,4 +63,10 @@ type UploadResp struct {
 	Path      string `json:"path"`
 	TraceID   string `json:"trace_id"`
 	RequestID string `json:"requestId"`
+}
+
+type Object struct {
+	model.Object
+	model.Thumbnail
+	ParentID string
 }

--- a/drivers/onedrive/driver.go
+++ b/drivers/onedrive/driver.go
@@ -2,14 +2,13 @@ package onedrive
 
 import (
 	"context"
+	"fmt"
 	"net/http"
-	stdpath "path"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
-	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/go-resty/resty/v2"
 )
@@ -45,7 +44,7 @@ func (d *Onedrive) List(ctx context.Context, dir model.Obj, args model.ListArgs)
 		return nil, err
 	}
 	return utils.SliceConvert(files, func(src File) (model.Obj, error) {
-		return fileToObj(src), nil
+		return fileToObj(src, dir.GetID()), nil
 	})
 }
 
@@ -90,18 +89,21 @@ func (d *Onedrive) Move(ctx context.Context, srcObj, dstDir model.Obj) error {
 }
 
 func (d *Onedrive) Rename(ctx context.Context, srcObj model.Obj, newName string) error {
-	dstDir, err := op.GetUnwrap(ctx, d, stdpath.Dir(srcObj.GetPath()))
-	if err != nil {
-		return err
+	//dstDir, err := op.GetUnwrap(ctx, d, stdpath.Dir(srcObj.GetPath()))
+	var parentID string
+	if o, ok := srcObj.(*Object); ok {
+		parentID = o.ParentID
+	} else {
+		return fmt.Errorf("srcObj is not Object")
 	}
 	data := base.Json{
 		"parentReference": base.Json{
-			"id": dstDir.GetID(),
+			"id": parentID,
 		},
 		"name": newName,
 	}
 	url := d.GetMetaUrl(false, srcObj.GetPath())
-	_, err = d.Request(url, http.MethodPatch, func(req *resty.Request) {
+	_, err := d.Request(url, http.MethodPatch, func(req *resty.Request) {
 		req.SetBody(data)
 	}, nil)
 	return err

--- a/drivers/onedrive/driver.go
+++ b/drivers/onedrive/driver.go
@@ -90,7 +90,7 @@ func (d *Onedrive) Move(ctx context.Context, srcObj, dstDir model.Obj) error {
 }
 
 func (d *Onedrive) Rename(ctx context.Context, srcObj model.Obj, newName string) error {
-	dstDir, err := op.Get(ctx, d, stdpath.Dir(srcObj.GetPath()))
+	dstDir, err := op.GetUnwrap(ctx, d, stdpath.Dir(srcObj.GetPath()))
 	if err != nil {
 		return err
 	}

--- a/drivers/onedrive/types.go
+++ b/drivers/onedrive/types.go
@@ -42,21 +42,29 @@ type File struct {
 	} `json:"parentReference"`
 }
 
-func fileToObj(f File) *model.ObjThumbURL {
+type Object struct {
+	model.ObjThumbURL
+	ParentID string
+}
+
+func fileToObj(f File, parentID string) *Object {
 	thumb := ""
 	if len(f.Thumbnails) > 0 {
 		thumb = f.Thumbnails[0].Medium.Url
 	}
-	return &model.ObjThumbURL{
-		Object: model.Object{
-			ID:       f.Id,
-			Name:     f.Name,
-			Size:     f.Size,
-			Modified: f.LastModifiedDateTime,
-			IsFolder: f.File == nil,
+	return &Object{
+		ObjThumbURL: model.ObjThumbURL{
+			Object: model.Object{
+				ID:       f.Id,
+				Name:     f.Name,
+				Size:     f.Size,
+				Modified: f.LastModifiedDateTime,
+				IsFolder: f.File == nil,
+			},
+			Thumbnail: model.Thumbnail{Thumbnail: thumb},
+			Url:       model.Url{Url: f.Url},
 		},
-		Thumbnail: model.Thumbnail{Thumbnail: thumb},
-		Url:       model.Url{Url: f.Url},
+		ParentID: parentID,
 	}
 }
 

--- a/drivers/quark/driver.go
+++ b/drivers/quark/driver.go
@@ -51,11 +51,6 @@ func (d *Quark) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 	})
 }
 
-//func (d *Quark) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// TODO this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *Quark) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	data := base.Json{
 		"fids": []string{file.GetID()},

--- a/drivers/s3/driver.go
+++ b/drivers/s3/driver.go
@@ -57,11 +57,6 @@ func (d *S3) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]mo
 	return d.listV1(dir.GetPath())
 }
 
-//func (d *S3) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *S3) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	path := getKey(file.GetPath(), false)
 	disposition := fmt.Sprintf(`attachment;filename="%s"`, url.QueryEscape(stdpath.Base(path)))

--- a/drivers/sftp/driver.go
+++ b/drivers/sftp/driver.go
@@ -47,11 +47,6 @@ func (d *SFTP) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]
 	})
 }
 
-//func (d *SFTP) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *SFTP) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	remoteFile, err := d.client.Open(file.GetPath())
 	if err != nil {

--- a/drivers/smb/driver.go
+++ b/drivers/smb/driver.go
@@ -69,11 +69,6 @@ func (d *SMB) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]m
 	return files, nil
 }
 
-//func (d *SMB) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *SMB) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	if err := d.checkConn(); err != nil {
 		return nil, err

--- a/drivers/teambition/driver.go
+++ b/drivers/teambition/driver.go
@@ -37,11 +37,6 @@ func (d *Teambition) List(ctx context.Context, dir model.Obj, args model.ListArg
 	return d.getFiles(dir.GetID())
 }
 
-//func (d *Teambition) Get(ctx context.Context, path string) (model.Obj, error) {
-//	//  this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *Teambition) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	if u, ok := file.(model.URL); ok {
 		url := u.URL()

--- a/drivers/template/driver.go
+++ b/drivers/template/driver.go
@@ -36,11 +36,6 @@ func (d *Template) List(ctx context.Context, dir model.Obj, args model.ListArgs)
 	return nil, errs.NotImplement
 }
 
-//func (d *Template) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *Template) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	// TODO return link of file
 	return nil, errs.NotImplement

--- a/drivers/thunder/types.go
+++ b/drivers/thunder/types.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"time"
-
-	"github.com/alist-org/alist/v3/pkg/utils"
 )
 
 type ErrResp struct {
@@ -149,7 +147,7 @@ type Files struct {
 }
 
 func (c *Files) GetSize() int64     { size, _ := strconv.ParseInt(c.Size, 10, 64); return size }
-func (c *Files) GetName() string    { return utils.MappingName(c.Name) }
+func (c *Files) GetName() string    { return c.Name }
 func (c *Files) ModTime() time.Time { return c.ModifiedTime }
 func (c *Files) IsDir() bool        { return c.Kind == FOLDER }
 func (c *Files) GetID() string      { return c.ID }

--- a/drivers/uss/driver.go
+++ b/drivers/uss/driver.go
@@ -71,11 +71,6 @@ func (d *USS) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]m
 	return res, err
 }
 
-//func (d *USS) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *USS) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	key := getKey(file.GetPath(), false)
 	host := d.CustomHost

--- a/drivers/webdav/driver.go
+++ b/drivers/webdav/driver.go
@@ -62,11 +62,6 @@ func (d *WebDav) List(ctx context.Context, dir model.Obj, args model.ListArgs) (
 	})
 }
 
-//func (d *WebDav) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *WebDav) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	url, header, err := d.client.Link(file.GetPath())
 	if err != nil {

--- a/drivers/yandex_disk/driver.go
+++ b/drivers/yandex_disk/driver.go
@@ -45,11 +45,6 @@ func (d *YandexDisk) List(ctx context.Context, dir model.Obj, args model.ListArg
 	})
 }
 
-//func (d *YandexDisk) Get(ctx context.Context, path string) (model.Obj, error) {
-//	// this is optional
-//	return nil, errs.NotImplement
-//}
-
 func (d *YandexDisk) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	var resp DownResp
 	_, err := d.request("/download", http.MethodGet, func(req *resty.Request) {

--- a/internal/db/meta.go
+++ b/internal/db/meta.go
@@ -19,7 +19,7 @@ var metaCache = cache.NewMemCache(cache.WithShards[*model.Meta](2))
 var metaG singleflight.Group[*model.Meta]
 
 func GetNearestMeta(path string) (*model.Meta, error) {
-	path = utils.StandardizePath(path)
+	path = utils.FixAndCleanPath(path)
 	meta, err := GetMetaByPath(path)
 	if err == nil {
 		return meta, nil

--- a/internal/db/searchnode.go
+++ b/internal/db/searchnode.go
@@ -29,6 +29,7 @@ func BatchCreateSearchNodes(nodes *[]model.SearchNode) error {
 }
 
 func DeleteSearchNodesByParent(prefix string) error {
+	prefix = utils.FixAndCleanPath(prefix)
 	err := db.Where(whereInParent(prefix)).Delete(&model.SearchNode{}).Error
 	if err != nil {
 		return err
@@ -36,7 +37,7 @@ func DeleteSearchNodesByParent(prefix string) error {
 	dir, name := path.Split(prefix)
 	return db.Where(fmt.Sprintf("%s = ? AND %s = ?",
 		columnName("parent"), columnName("name")),
-		utils.StandardizePath(dir), name).Delete(&model.SearchNode{}).Error
+		dir, name).Delete(&model.SearchNode{}).Error
 }
 
 func ClearSearchNodes() error {

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -39,7 +39,7 @@ type Reader interface {
 }
 
 type Getter interface {
-	Get(ctx context.Context, path string) (model.Obj, error)
+	GetRoot(ctx context.Context) (model.Obj, error)
 }
 
 type Writer interface {

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -80,7 +80,7 @@ func Remove(ctx context.Context, path string) error {
 	return err
 }
 
-func PutDirectly(ctx context.Context, dstDirPath string, file model.FileStreamer) error {
+func PutDirectly(ctx context.Context, dstDirPath string, file *model.FileStream) error {
 	err := putDirectly(ctx, dstDirPath, file)
 	if err != nil {
 		log.Errorf("failed put %s: %+v", dstDirPath, err)
@@ -88,7 +88,7 @@ func PutDirectly(ctx context.Context, dstDirPath string, file model.FileStreamer
 	return err
 }
 
-func PutAsTask(dstDirPath string, file model.FileStreamer) error {
+func PutAsTask(dstDirPath string, file *model.FileStream) error {
 	err := putAsTask(dstDirPath, file)
 	if err != nil {
 		log.Errorf("failed put %s: %+v", dstDirPath, err)

--- a/internal/fs/get.go
+++ b/internal/fs/get.go
@@ -12,7 +12,7 @@ import (
 )
 
 func get(ctx context.Context, path string) (model.Obj, error) {
-	path = utils.StandardizePath(path)
+	path = utils.FixAndCleanPath(path)
 	// maybe a virtual file
 	if path != "/" {
 		virtualFiles := op.GetStorageVirtualFilesByPath(stdpath.Dir(path))

--- a/internal/fs/put.go
+++ b/internal/fs/put.go
@@ -18,7 +18,7 @@ var UploadTaskManager = task.NewTaskManager(3, func(tid *uint64) {
 })
 
 // putAsTask add as a put task and return immediately
-func putAsTask(dstDirPath string, file model.FileStreamer) error {
+func putAsTask(dstDirPath string, file *model.FileStream) error {
 	storage, dstDirActualPath, err := op.GetStorageAndActualPath(dstDirPath)
 	if err != nil {
 		return errors.WithMessage(err, "failed get storage")
@@ -43,7 +43,7 @@ func putAsTask(dstDirPath string, file model.FileStreamer) error {
 }
 
 // putDirect put the file and return after finish
-func putDirectly(ctx context.Context, dstDirPath string, file model.FileStreamer) error {
+func putDirectly(ctx context.Context, dstDirPath string, file *model.FileStream) error {
 	storage, dstDirActualPath, err := op.GetStorageAndActualPath(dstDirPath)
 	if err != nil {
 		return errors.WithMessage(err, "failed get storage")

--- a/internal/fs/util.go
+++ b/internal/fs/util.go
@@ -35,7 +35,7 @@ func containsByName(files []model.Obj, file model.Obj) bool {
 
 var httpClient = &http.Client{}
 
-func getFileStreamFromLink(file model.Obj, link *model.Link) (model.FileStreamer, error) {
+func getFileStreamFromLink(file model.Obj, link *model.Link) (*model.FileStream, error) {
 	var rc io.ReadCloser
 	mimetype := utils.GetMimeType(file.GetName())
 	if link.Data != nil {

--- a/internal/model/obj.go
+++ b/internal/model/obj.go
@@ -8,6 +8,10 @@ import (
 	"github.com/maruel/natural"
 )
 
+type Unwarp interface {
+	Unwarp() Obj
+}
+
 type Obj interface {
 	GetSize() int64
 	GetName() string

--- a/internal/model/obj.go
+++ b/internal/model/obj.go
@@ -8,8 +8,8 @@ import (
 	"github.com/maruel/natural"
 )
 
-type UnwarpObj interface {
-	Unwarp() Obj
+type UnwrapObj interface {
+	Unwrap() Obj
 }
 
 type Obj interface {
@@ -94,8 +94,8 @@ func ExtractFolder(objs []Obj, extractFolder string) {
 	})
 }
 
-func WarpObjsName(objs []Obj) {
+func WrapObjsName(objs []Obj) {
 	for i := 0; i < len(objs); i++ {
-		objs[i] = &ObjWarpName{Obj: objs[i]}
+		objs[i] = &ObjWrapName{Obj: objs[i]}
 	}
 }

--- a/internal/model/obj.go
+++ b/internal/model/obj.go
@@ -8,7 +8,7 @@ import (
 	"github.com/maruel/natural"
 )
 
-type Unwarp interface {
+type UnwarpObj interface {
 	Unwarp() Obj
 }
 
@@ -17,6 +17,9 @@ type Obj interface {
 	GetName() string
 	ModTime() time.Time
 	IsDir() bool
+
+	// The internal information of the driver.
+	// If you want to use it, please understand what it means
 	GetID() string
 	GetPath() string
 }
@@ -89,4 +92,10 @@ func ExtractFolder(objs []Obj, extractFolder string) {
 		}
 		return false
 	})
+}
+
+func WarpObjsName(objs []Obj) {
+	for i := 0; i < len(objs); i++ {
+		objs[i] = &ObjWarpName{Obj: objs[i]}
+	}
 }

--- a/internal/model/obj.go
+++ b/internal/model/obj.go
@@ -31,6 +31,7 @@ type FileStreamer interface {
 	SetReadCloser(io.ReadCloser)
 	NeedStore() bool
 	GetReadCloser() io.ReadCloser
+	GetOld() Obj
 }
 
 type URL interface {

--- a/internal/model/object.go
+++ b/internal/model/object.go
@@ -6,16 +6,16 @@ import (
 	"github.com/alist-org/alist/v3/pkg/utils"
 )
 
-type ObjWarpName struct {
+type ObjWrapName struct {
 	Name string
 	Obj
 }
 
-func (o *ObjWarpName) Unwarp() Obj {
+func (o *ObjWrapName) Unwrap() Obj {
 	return o.Obj
 }
 
-func (o *ObjWarpName) GetName() string {
+func (o *ObjWrapName) GetName() string {
 	if o.Name == "" {
 		o.Name = utils.MappingName(o.Obj.GetName())
 	}

--- a/internal/model/object.go
+++ b/internal/model/object.go
@@ -32,7 +32,7 @@ type Object struct {
 }
 
 func (o *Object) GetName() string {
-	return utils.MappingName(o.Name)
+	return o.Name
 }
 
 func (o *Object) GetSize() int64 {

--- a/internal/model/object.go
+++ b/internal/model/object.go
@@ -6,6 +6,22 @@ import (
 	"github.com/alist-org/alist/v3/pkg/utils"
 )
 
+type ObjWarpName struct {
+	Name string
+	Obj
+}
+
+func (o *ObjWarpName) Unwarp() Obj {
+	return o.Obj
+}
+
+func (o *ObjWarpName) GetName() string {
+	if o.Name == "" {
+		o.Name = utils.MappingName(o.Obj.GetName())
+	}
+	return o.Name
+}
+
 type Object struct {
 	ID       string
 	Path     string

--- a/internal/model/stream.go
+++ b/internal/model/stream.go
@@ -9,6 +9,7 @@ type FileStream struct {
 	io.ReadCloser
 	Mimetype     string
 	WebPutAsTask bool
+	Old          Obj
 }
 
 func (f *FileStream) GetMimetype() string {
@@ -25,4 +26,8 @@ func (f *FileStream) GetReadCloser() io.ReadCloser {
 
 func (f *FileStream) SetReadCloser(rc io.ReadCloser) {
 	f.ReadCloser = rc
+}
+
+func (f *FileStream) GetOld() Obj {
+	return f.Old
 }

--- a/internal/op/const.go
+++ b/internal/op/const.go
@@ -1,3 +1,4 @@
 package op
 
-var WORK = "work"
+const WORK = "work"
+const ROOT_NAME = "root"

--- a/internal/op/const.go
+++ b/internal/op/const.go
@@ -1,4 +1,6 @@
 package op
 
-const WORK = "work"
-const ROOT_NAME = "root"
+const (
+	WORK     = "work"
+	RootName = "root"
+)

--- a/internal/op/fs.go
+++ b/internal/op/fs.go
@@ -52,16 +52,16 @@ func List(ctx context.Context, storage driver.Driver, path string, args model.Li
 		return nil, errors.WithStack(errs.NotFolder)
 	}
 	objs, err, _ := listG.Do(key, func() ([]model.Obj, error) {
-		// unwarp obj
-		if obj, ok := dir.(model.UnwarpObj); ok {
-			dir = obj.Unwarp()
+		// unwrap obj
+		if obj, ok := dir.(model.UnwrapObj); ok {
+			dir = obj.Unwrap()
 		}
 		files, err := storage.List(ctx, dir, args)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to list objs")
 		}
 		// warp obg name
-		model.WarpObjsName(files)
+		model.WrapObjsName(files)
 
 		// call hooks
 		go func(reqPath string, files []model.Obj) {
@@ -90,20 +90,20 @@ func Get(ctx context.Context, storage driver.Driver, path string) (model.Obj, er
 
 	// is root folder
 	if utils.PathEqual(path, "/") {
-		var rootObg model.Obj
+		var rootObj model.Obj
 		switch r := storage.GetAddition().(type) {
 		case driver.IRootId:
-			rootObg = &model.Object{
+			rootObj = &model.Object{
 				ID:       r.GetRootId(),
-				Name:     ROOT_NAME,
+				Name:     RootName,
 				Size:     0,
 				Modified: storage.GetStorage().Modified,
 				IsFolder: true,
 			}
 		case driver.IRootPath:
-			rootObg = &model.Object{
+			rootObj = &model.Object{
 				Path:     r.GetRootPath(),
-				Name:     ROOT_NAME,
+				Name:     RootName,
 				Size:     0,
 				Modified: storage.GetStorage().Modified,
 				IsFolder: true,
@@ -114,15 +114,15 @@ func Get(ctx context.Context, storage driver.Driver, path string) (model.Obj, er
 				if err != nil {
 					return nil, errors.WithMessage(err, "failed get root obj")
 				}
-				rootObg = obj
+				rootObj = obj
 			}
 		}
-		if rootObg == nil {
+		if rootObj == nil {
 			return nil, errors.Errorf("please implement IRootPath or IRootId or Getter method")
 		}
-		return &model.ObjWarpName{
-			Name: ROOT_NAME,
-			Obj:  rootObg,
+		return &model.ObjWrapName{
+			Name: RootName,
+			Obj:  rootObj,
 		}, nil
 	}
 

--- a/internal/op/fs.go
+++ b/internal/op/fs.go
@@ -319,7 +319,7 @@ func Remove(ctx context.Context, storage driver.Driver, path string) error {
 	return errors.WithStack(err)
 }
 
-func Put(ctx context.Context, storage driver.Driver, dstDirPath string, file model.FileStreamer, up driver.UpdateProgress) error {
+func Put(ctx context.Context, storage driver.Driver, dstDirPath string, file *model.FileStream, up driver.UpdateProgress) error {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
 		return errors.Errorf("storage not init: %s", storage.GetStorage().Status)
 	}
@@ -345,9 +345,10 @@ func Put(ctx context.Context, storage driver.Driver, dstDirPath string, file mod
 			if err != nil {
 				return errors.WithMessagef(err, "failed remove file that exist and have size 0")
 			}
+		} else {
+			file.Old = fi
 		}
 	}
-
 	err = MakeDir(ctx, storage, dstDirPath)
 	if err != nil {
 		return errors.WithMessagef(err, "failed to make dir [%s]", dstDirPath)

--- a/internal/op/fs.go
+++ b/internal/op/fs.go
@@ -56,9 +56,14 @@ func List(ctx context.Context, storage driver.Driver, path string, args model.Li
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to list objs")
 		}
-		// warp obg name
+		// set path
+		for _, f := range files {
+			if s, ok := f.(model.SetPath); ok && f.GetPath() == "" && dir.GetPath() != "" {
+				s.SetPath(stdpath.Join(dir.GetPath(), f.GetName()))
+			}
+		}
+		// warp obj name
 		model.WrapObjsName(files)
-
 		// call hooks
 		go func(reqPath string, files []model.Obj) {
 			for _, hook := range objsUpdateHooks {

--- a/internal/op/path.go
+++ b/internal/op/path.go
@@ -1,7 +1,6 @@
 package op
 
 import (
-	stdpath "path"
 	"strings"
 
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -10,30 +9,17 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// ActualPath Get the actual path
-// !!! maybe and \ in the path when use windows local
-func ActualPath(storage driver.Additional, rawPath string) string {
-	if i, ok := storage.(driver.IRootPath); ok {
-		rawPath = stdpath.Join(i.GetRootPath(), rawPath)
-	}
-	return utils.StandardizePath(rawPath)
-}
-
 // GetStorageAndActualPath Get the corresponding storage and actual path
 // for path: remove the mount path prefix and join the actual root folder if exists
-func GetStorageAndActualPath(rawPath string) (driver.Driver, string, error) {
-	rawPath = utils.StandardizePath(rawPath)
-	// why can remove this check? because reqPath has joined the base_path of user, no relative path
-	//if strings.Contains(rawPath, "..") {
-	//	return nil, "", errors.WithStack(errs.RelativePath)
-	//}
-	storage := GetBalancedStorage(rawPath)
+func GetStorageAndActualPath(rawPath string) (storage driver.Driver, actualPath string, err error) {
+	rawPath = utils.FixAndCleanPath(rawPath)
+	storage = GetBalancedStorage(rawPath)
 	if storage == nil {
-		return nil, "", errors.Errorf("can't find storage with rawPath: %s", rawPath)
+		err = errors.Errorf("can't find storage with rawPath: %s", rawPath)
+		return
 	}
 	log.Debugln("use storage: ", storage.GetStorage().MountPath)
 	virtualPath := utils.GetActualVirtualPath(storage.GetStorage().MountPath)
-	actualPath := strings.TrimPrefix(rawPath, virtualPath)
-	actualPath = ActualPath(storage.GetAddition(), actualPath)
-	return storage, actualPath, nil
+	actualPath = utils.FixAndCleanPath(strings.TrimPrefix(rawPath, virtualPath))
+	return
 }

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"os"
 	"path"
@@ -43,7 +42,7 @@ func CopyFile(src, dst string) error {
 // CopyDir Dir copies a whole directory recursively
 func CopyDir(src string, dst string) error {
 	var err error
-	var fds []os.FileInfo
+	var fds []os.DirEntry
 	var srcinfo os.FileInfo
 
 	if srcinfo, err = os.Stat(src); err != nil {
@@ -52,7 +51,7 @@ func CopyDir(src string, dst string) error {
 	if err = os.MkdirAll(dst, srcinfo.Mode()); err != nil {
 		return err
 	}
-	if fds, err = ioutil.ReadDir(src); err != nil {
+	if fds, err = os.ReadDir(src); err != nil {
 		return err
 	}
 	for _, fd := range fds {

--- a/pkg/utils/path.go
+++ b/pkg/utils/path.go
@@ -3,33 +3,37 @@ package utils
 import (
 	"net/url"
 	stdpath "path"
-	"path/filepath"
-	"runtime"
 	"strings"
-
-	"github.com/alist-org/alist/v3/internal/errs"
 )
 
-// StandardizePath convert path like '/' '/root' '/a/b'
-func StandardizePath(path string) string {
-	path = strings.TrimSuffix(path, "/")
-	// abs path
-	if filepath.IsAbs(path) && runtime.GOOS == "windows" {
-		return path
-	}
-	// relative path with prefix '..'
-	if strings.HasPrefix(path, ".") {
-		return path
-	}
+// FixAndCleanPath
+// The upper layer of the root directory is still the root directory.
+// So ".." And "." will be cleared
+// for example
+// 1. ".." or "." => "/"
+// 2. "../..." or "./..." => "/..."
+// 3. "../.x." or "./.x." => "/.x."
+// 4. "x//\\y" = > "/z/x"
+func FixAndCleanPath(path string) string {
+	path = strings.ReplaceAll(path, "\\", "/")
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
+	}
+	return stdpath.Clean(path)
+}
+
+// PathAddSeparatorSuffix Add path '/' suffix
+// for example /root => /root/
+func PathAddSeparatorSuffix(path string) string {
+	if !strings.HasSuffix(path, "/") {
+		path = path + "/"
 	}
 	return path
 }
 
 // PathEqual judge path is equal
 func PathEqual(path1, path2 string) bool {
-	return StandardizePath(path1) == StandardizePath(path2)
+	return FixAndCleanPath(path1) == FixAndCleanPath(path2)
 }
 
 func Ext(path string) string {
@@ -64,8 +68,5 @@ func EncodePath(path string, all ...bool) string {
 }
 
 func JoinBasePath(basePath, reqPath string) (string, error) {
-	if strings.HasSuffix(reqPath, "..") || strings.Contains(reqPath, "../") {
-		return "", errs.RelativePath
-	}
-	return stdpath.Join(basePath, reqPath), nil
+	return stdpath.Join(FixAndCleanPath(basePath), FixAndCleanPath(reqPath)), nil
 }

--- a/pkg/utils/path_test.go
+++ b/pkg/utils/path_test.go
@@ -5,3 +5,18 @@ import "testing"
 func TestEncodePath(t *testing.T) {
 	t.Log(EncodePath("http://localhost:5244/d/123#.png"))
 }
+
+func TestFixAndCleanPath(t *testing.T) {
+	datas := map[string]string{
+		"":                          "/",
+		".././":                     "/",
+		"../../.../":                "/...",
+		"x//\\y/":                   "/x/y",
+		".././.x/.y/.//..x../..y..": "/.x/.y/..x../..y..",
+	}
+	for key, value := range datas {
+		if FixAndCleanPath(key) != value {
+			t.Logf("raw %s fix fail", key)
+		}
+	}
+}

--- a/server/handles/meta.go
+++ b/server/handles/meta.go
@@ -44,7 +44,7 @@ func CreateMeta(c *gin.Context) {
 		common.ErrorStrResp(c, fmt.Sprintf("%s is illegal: %s", r, err.Error()), 400)
 		return
 	}
-	req.Path = utils.StandardizePath(req.Path)
+	req.Path = utils.FixAndCleanPath(req.Path)
 	if err := db.CreateMeta(&req); err != nil {
 		common.ErrorResp(c, err, 500, true)
 	} else {
@@ -63,7 +63,7 @@ func UpdateMeta(c *gin.Context) {
 		common.ErrorStrResp(c, fmt.Sprintf("%s is illegal: %s", r, err.Error()), 400)
 		return
 	}
-	req.Path = utils.StandardizePath(req.Path)
+	req.Path = utils.FixAndCleanPath(req.Path)
 	if err := db.UpdateMeta(&req); err != nil {
 		common.ErrorResp(c, err, 500, true)
 	} else {

--- a/server/middlewares/down.go
+++ b/server/middlewares/down.go
@@ -42,7 +42,7 @@ func Down(c *gin.Context) {
 // TODO: implement
 // path maybe contains # ? etc.
 func parsePath(path string) string {
-	return utils.StandardizePath(path)
+	return utils.FixAndCleanPath(path)
 }
 
 func needSign(meta *model.Meta, path string) bool {

--- a/server/static/config.go
+++ b/server/static/config.go
@@ -31,7 +31,7 @@ func getSiteConfig() SiteConfig {
 		siteConfig.BasePath = setting.GetStr(conf.BasePath)
 	}
 	if siteConfig.BasePath != "" {
-		siteConfig.BasePath = utils.StandardizePath(siteConfig.BasePath)
+		siteConfig.BasePath = utils.FixAndCleanPath(siteConfig.BasePath)
 	}
 	if siteConfig.Cdn == "" {
 		siteConfig.Cdn = siteConfig.BasePath


### PR DESCRIPTION
具体修改说明
1.因为Get接口需要传入path,为方便起见所以删除
2.由于mega driver 在启动后才可以获取到root对象,所以添加GetRoot接口
3.将名称映射提取到op包中,删除所有driver中的映射关系
4.将driver和程序内部的路径关联完全分离,互不干扰
5.程序内部强制使用linux路径规则,除文件交互部分

由于部分网盘没有账号,无法测试功能是否异常