### PR TITLE
remove http schame generate when get file info

### DIFF
--- a/server/handles/fsread.go
+++ b/server/handles/fsread.go
@@ -266,8 +266,7 @@ func FsGet(c *gin.Context) {
 					utils.EncodePath(reqPath, true),
 					sign.Sign(reqPath))
 			} else {
-				rawURL = fmt.Sprintf("%s/p%s?sign=%s",
-					common.GetApiUrl(c.Request),
+				rawURL = fmt.Sprintf("/p%s?sign=%s",
 					utils.EncodePath(reqPath, true),
 					sign.Sign(reqPath))
 			}


### PR DESCRIPTION
文件get接口返回的url包含host信息，使用nginx等proxy场合会出错，应只返回uri信息。
可能不止这一处需要修改