### PR TITLE
feat: installing `tzdata` in the docker image (#1165)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:edge as builder
 LABEL stage=go-builder
 WORKDIR /app/
 COPY ./ ./
-RUN apk add --no-cache bash git go gcc musl-dev curl; \
+RUN apk add --no-cache bash curl gcc git go musl-dev; \
     bash build.sh release docker
 
 FROM alpine:edge
@@ -11,7 +11,7 @@ VOLUME /opt/alist/data/
 WORKDIR /opt/alist/
 COPY --from=builder /app/bin/alist ./
 COPY entrypoint.sh /entrypoint.sh
-RUN apk add ca-certificates bash su-exec; \
+RUN apk add --no-cache bash ca-certificates su-exec tzdata; \
     chmod +x /entrypoint.sh
 ENV PUID=0 PGID=0 UMASK=022
 EXPOSE 5244

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,6 @@ services:
       - PUID=0
       - PGID=0
       - UMASK=022
+      - TZ=UTC
     container_name: alist
     image: 'xhofe/alist:latest'


### PR DESCRIPTION
allows the user to modify the container time zone via the `TZ` variable.

and add `-no-cache` to prevent `apk` from writing to repository metadata.