### PR TITLE
feat: dockerfile add aria2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ VOLUME /opt/alist/data/
 WORKDIR /opt/alist/
 COPY --from=builder /app/bin/alist ./
 COPY entrypoint.sh /entrypoint.sh
-RUN apk add --no-cache bash ca-certificates su-exec tzdata; \
+RUN apk add --no-cache bash ca-certificates su-exec tzdata aria2; \
     chmod +x /entrypoint.sh
 ENV PUID=0 PGID=0 UMASK=022
 EXPOSE 5244

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,6 @@ chown -R ${PUID}:${PGID} /opt/alist/
 
 umask ${UMASK}
 
+exec su-exec ${PUID}:${PGID} nohup aria2c --enable-rpc --rpc-allow-origin-all > /dev/null 2>&1 &
+
 exec su-exec ${PUID}:${PGID} ./alist server --no-prefix


### PR DESCRIPTION
notes:
Adding aria2 inside the container may
break the user's previous architecture,
they may have integrated aria2 through
other means.
So we simply add aria2 to avoid this
problem, because it works inside the
container.
Might need some good advice on how to
configure aria2 and expose aria2's rpc
port.

resolve https://github.com/alist-org/alist/issues/3025