### PR TITLE
feat: add aliyundrive internal upload (aliyun ECS for Beijing area only)

### DIFF
--- a/drivers/aliyundrive/driver.go
+++ b/drivers/aliyundrive/driver.go
@@ -251,7 +251,11 @@ func (d *AliDrive) Put(ctx context.Context, dstDir model.Obj, stream model.FileS
 		if utils.IsCanceled(ctx) {
 			return ctx.Err()
 		}
-		req, err := http.NewRequest("PUT", partInfo.UploadUrl, io.LimitReader(file, DEFAULT))
+		url := partInfo.UploadUrl
+		if d.InternalUpload {
+			url = partInfo.InternalUploadUrl
+		}
+		req, err := http.NewRequest("PUT", url, io.LimitReader(file, DEFAULT))
 		if err != nil {
 			return err
 		}

--- a/drivers/aliyundrive/meta.go
+++ b/drivers/aliyundrive/meta.go
@@ -11,6 +11,7 @@ type Addition struct {
 	OrderBy        string `json:"order_by" type:"select" options:"name,size,updated_at,created_at"`
 	OrderDirection string `json:"order_direction" type:"select" options:"ASC,DESC"`
 	RapidUpload    bool   `json:"rapid_upload"`
+	InternalUpload bool   `json:"internal_upload"`
 }
 
 var config = driver.Config{

--- a/drivers/aliyundrive/types.go
+++ b/drivers/aliyundrive/types.go
@@ -48,7 +48,8 @@ type UploadResp struct {
 	FileId       string `json:"file_id"`
 	UploadId     string `json:"upload_id"`
 	PartInfoList []struct {
-		UploadUrl string `json:"upload_url"`
+		UploadUrl         string `json:"upload_url"`
+		InternalUploadUrl string `json:"internal_upload_url"`
 	} `json:"part_info_list"`
 
 	RapidUpload bool `json:"rapid_upload"`


### PR DESCRIPTION
Aliyun ECS in Beijing can use internal network to accelerate upload