### PR TITLE
Change default permissions to 0755 when create a new folder to avoid some security issues

### DIFF
--- a/drivers/local/driver.go
+++ b/drivers/local/driver.go
@@ -151,7 +151,7 @@ func (d *Local) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (
 
 func (d *Local) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {
 	fullPath := filepath.Join(parentDir.GetPath(), dirName)
-	err := os.MkdirAll(fullPath, 0777)
+	err := os.MkdirAll(fullPath, 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Change default permissions to 0755 when create a new folder to some avoid security issues