### PR TITLE
refactor(cmd): change no-prefix default value

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ func Execute() {
 func init() {
 	RootCmd.PersistentFlags().StringVar(&flags.DataDir, "data", "data", "config file")
 	RootCmd.PersistentFlags().BoolVar(&flags.Debug, "debug", false, "start with debug mode")
-	RootCmd.PersistentFlags().BoolVar(&flags.NoPrefix, "no-prefix", false, "disable env prefix")
+	RootCmd.PersistentFlags().BoolVar(&flags.NoPrefix, "no-prefix", true, "disable env prefix")
 	RootCmd.PersistentFlags().BoolVar(&flags.Dev, "dev", false, "start with dev mode")
 	RootCmd.PersistentFlags().BoolVar(&flags.ForceBinDir, "force-bin-dir", false, "Force to use the directory where the binary file is located as data directory")
 }


### PR DESCRIPTION
when deploy to k8s,if your container's name is "alist",container's env will start with "ALIST_",this may cause you can't get password when use "./alist admin"

in k8s, can't get passowrd without any flags, 
![image](https://user-images.githubusercontent.com/34703350/219529763-1c886940-b442-4ec2-aa8d-0f85d9d52a2f.png)
![image](https://user-images.githubusercontent.com/34703350/219529906-09396182-9ae7-4829-9fae-f5826aefc77d.png)
