### PR TITLE
feat(qbittorrent): also delete tags when deleting qbittorrent tasks

### DIFF
--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -15,7 +15,7 @@ type Client interface {
 	AddFromLink(link string, savePath string, id string) error
 	GetInfo(id string) (TorrentInfo, error)
 	GetFiles(id string) ([]FileInfo, error)
-	Delete(id string) error
+	Delete(id string, deleteFiles bool) error
 }
 
 type client struct {
@@ -326,7 +326,7 @@ func (c *client) GetFiles(id string) ([]FileInfo, error) {
 	return infos, nil
 }
 
-func (c *client) Delete(id string) error {
+func (c *client) Delete(id string, deleteFiles bool) error {
 	err := c.checkAuthorization()
 	if err != nil {
 		return err
@@ -338,13 +338,17 @@ func (c *client) Delete(id string) error {
 	}
 	v := url.Values{}
 	v.Set("hashes", info.Hash)
-	v.Set("deleteFiles", "false")
+	if deleteFiles {
+		v.Set("deleteFiles", "true")
+	} else {
+		v.Set("deleteFiles", "false")
+	}
 	response, err := c.post("/api/v2/torrents/delete", v)
 	if err != nil {
 		return err
 	}
 	if response.StatusCode != 200 {
-		return errors.New("failed")
+		return errors.New("failed to delete qbittorrent task")
 	}
 	return nil
 }

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -350,5 +350,15 @@ func (c *client) Delete(id string, deleteFiles bool) error {
 	if response.StatusCode != 200 {
 		return errors.New("failed to delete qbittorrent task")
 	}
+
+	v = url.Values{}
+	v.Set("tags", "alist-"+id)
+	response, err = c.post("/api/v2/torrents/deleteTags", v)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != 200 {
+		return errors.New("failed to delete qbittorrent tag")
+	}
 	return nil
 }

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -88,12 +88,6 @@ func TestAdd(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
-	// test add
-	err = c.login()
-	if err != nil {
-		t.Error(err)
-	}
 	err = c.AddFromLink(
 		"https://releases.ubuntu.com/22.04/ubuntu-22.04.1-desktop-amd64.iso.torrent",
 		"D:\\qBittorrentDownload\\alist",
@@ -145,7 +139,15 @@ func TestDelete(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = c.Delete("uuid-2")
+	err = c.AddFromLink(
+		"https://releases.ubuntu.com/22.04/ubuntu-22.04.1-desktop-amd64.iso.torrent",
+		"D:\\qBittorrentDownload\\alist",
+		"uuid-1",
+	)
+	if err != nil {
+		t.Error(err)
+	}
+	err = c.Delete("uuid-1", true)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/qbittorrent/monitor.go
+++ b/internal/qbittorrent/monitor.go
@@ -56,7 +56,8 @@ outer:
 	for {
 		select {
 		case <-m.tsk.Ctx.Done():
-			return qbclient.Delete(m.tsk.ID)
+			// delete qbittorrent task and downloaded files when the task exits with error
+			return qbclient.Delete(m.tsk.ID, true)
 		case <-time.After(time.Second * 2):
 			completed, err = m.update()
 			if completed {
@@ -113,7 +114,7 @@ func (m *Monitor) complete() error {
 	log.Debugf("files len: %d", len(files))
 	// delete qbittorrent task but do not delete the files before transferring to avoid qbittorrent
 	// accessing downloaded files and throw `cannot access the file because it is being used by another process` error
-	err = qbclient.Delete(m.tsk.ID)
+	err = qbclient.Delete(m.tsk.ID, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Delete qbittorrent tags when the task is done or stopped with an error to avoid leaving useless tags in qbittorrent client.