### PR TITLE
fix(webdav): `disabled` is not working in webdav

### DIFF
--- a/server/webdav.go
+++ b/server/webdav.go
@@ -68,7 +68,7 @@ func WebDAVAuth(c *gin.Context) {
 		c.Abort()
 		return
 	}
-	if !user.CanWebdavRead() {
+	if user.Disabled || !user.CanWebdavRead() {
 		if c.Request.Method == "OPTIONS" {
 			c.Set("user", guest)
 			c.Next()


### PR DESCRIPTION
A disabled user with webdav permission can use webdav normally, which is not allowed.