### PR TITLE
feat: allow override startup command for Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN apk add --no-cache bash ca-certificates su-exec tzdata; \
     chmod +x /entrypoint.sh
 ENV PUID=0 PGID=0 UMASK=022
 EXPOSE 5244
-ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "/entrypoint.sh" ]


### PR DESCRIPTION
This is to enable using the Docker image with different flags. E.g. `docker run xhofe/alist:latest ./alist server --data=mydata`

This used to be the behavior until #2818 changed it. This would make the image more re-usable.