### PR TITLE
fix(storage): explicitly set storages' status to disabled

### DIFF
--- a/internal/op/const.go
+++ b/internal/op/const.go
@@ -2,5 +2,6 @@ package op
 
 const (
 	WORK     = "work"
+	DISABLED = "disabled"
 	RootName = "root"
 )

--- a/internal/op/storage.go
+++ b/internal/op/storage.go
@@ -142,6 +142,7 @@ func DisableStorage(ctx context.Context, id uint) error {
 	}
 	// delete the storage in the memory
 	storage.Disabled = true
+	storage.SetStatus(DISABLED)
 	err = db.UpdateStorage(storage)
 	if err != nil {
 		return errors.WithMessage(err, "failed update storage in db")


### PR DESCRIPTION
Currently after disabling a storage, its status is still "work" while the switch button text indicates that the storage is disabled, which is very confusing and misleading.  
Set status explicitly when disabling storages to make things clear.