### PR TITLE
feat: update upload api to v4.0, add pagesize option (close #3753)

### DIFF
--- a/drivers/115/meta.go
+++ b/drivers/115/meta.go
@@ -6,8 +6,9 @@ import (
 )
 
 type Addition struct {
-	Cookie      string `json:"cookie"`
-	QRCodeToken string `json:"qrcode_token"`
+	Cookie      string `json:"cookie" type:"text" help:"one of QR code token and cookie required"`
+	QRCodeToken string `json:"qrcode_token" type:"text" help:"one of QR code token and cookie required"`
+	PageSize    int64  `json:"page_size" type:"number" default:"56" help:"list api per page size of 115 driver"`
 	driver.RootID
 }
 

--- a/drivers/115/util.go
+++ b/drivers/115/util.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36 115Browser/23.9.3.2 115disk/30.1.0"
+var UserAgent = driver.UA115Desktop
 
 func (d *Pan115) login() error {
 	var err error
@@ -38,7 +38,10 @@ func (d *Pan115) login() error {
 
 func (d *Pan115) getFiles(fileId string) ([]driver.File, error) {
 	res := make([]driver.File, 0)
-	files, err := d.client.List(fileId)
+	if d.PageSize <= 0 {
+		d.PageSize = driver.FileListLimit
+	}
+	files, err := d.client.ListWithLimit(fileId, d.PageSize)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alist-org/alist/v3
 go 1.19
 
 require (
-	github.com/SheltonZhu/115driver v1.0.13
+	github.com/SheltonZhu/115driver v1.0.14
 	github.com/Xhofe/go-cache v0.0.0-20220723083548-714439c8af9a
 	github.com/aws/aws-sdk-go v1.44.194
 	github.com/blevesearch/bleve/v2 v2.3.6

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/RoaringBitmap/roaring v0.9.4 h1:ckvZSX5gwCRaJYBNe7syNawCU5oruY9gQmjXlp4riwo=
 github.com/RoaringBitmap/roaring v0.9.4/go.mod h1:icnadbWcNyfEHlYdr+tDlOTih1Bf/h+rzPpv4sbomAA=
-github.com/SheltonZhu/115driver v1.0.13 h1:YEhQ3iMvd5TD6Xp1wKg+73KgdCMjc0pDoT1eCNXnA3M=
-github.com/SheltonZhu/115driver v1.0.13/go.mod h1:00ixivHH5HqDj4S7kAWbkuUrjtsJTxc7cGv5RMw3RVs=
+github.com/SheltonZhu/115driver v1.0.14 h1:uW3dl8J9KDMw+3gPxQdhTysoGhw0/uI1484GT9xhfU4=
+github.com/SheltonZhu/115driver v1.0.14/go.mod h1:00ixivHH5HqDj4S7kAWbkuUrjtsJTxc7cGv5RMw3RVs=
 github.com/Xhofe/go-cache v0.0.0-20220723083548-714439c8af9a h1:RenIAa2q4H8UcS/cqmwdT1WCWIAH5aumP8m8RpbqVsE=
 github.com/Xhofe/go-cache v0.0.0-20220723083548-714439c8af9a/go.mod h1:sSBbaOg90XwWKtpT56kVujF0bIeVITnPlssLclogS04=
 github.com/aead/ecdh v0.2.0 h1:pYop54xVaq/CEREFEcukHRZfTdjiWvYIsZDXXrBapQQ=


### PR DESCRIPTION
* 升级上传 api 版本到 `v4.0`
* 增加分页大小选项，多文件用户可适当调整数值，减少api请求次数，避免被WAF拦截。