### PR TITLE
fix: spaces in filename will be replaced with plus sign

### DIFF
--- a/drivers/s3/driver.go
+++ b/drivers/s3/driver.go
@@ -59,7 +59,8 @@ func (d *S3) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]mo
 
 func (d *S3) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	path := getKey(file.GetPath(), false)
-	disposition := fmt.Sprintf(`attachment;filename="%s"`, url.QueryEscape(stdpath.Base(path)))
+	filename := stdpath.Base(path)
+	disposition := fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`, filename, url.PathEscape(filename))
 	input := &s3.GetObjectInput{
 		Bucket: &d.Bucket,
 		Key:    &path,

--- a/server/common/proxy.go
+++ b/server/common/proxy.go
@@ -26,8 +26,9 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.
 		defer func() {
 			_ = link.Data.Close()
 		}()
+		filename := file.GetName()
 		w.Header().Set("Content-Type", "application/octet-stream")
-		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`, file.GetName(), url.QueryEscape(file.GetName())))
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`, filename, url.PathEscape(filename)))
 		w.Header().Set("Content-Length", strconv.FormatInt(file.GetSize(), 10))
 		if link.Header != nil {
 			// TODO clean header with blacklist or whitelist


### PR DESCRIPTION
修复了文件名中的空格会变成加号的问题。
原代码使用了url.QueryEscape，修改之后使用了url.PathEscape，会将所有字符处理为urlencoded
[我的项目](https://github.com/XZB-1248/Spark)中使用了url.PathEscape来处理文件名，一切正常