### PR TITLE
fix(trainbit): decode html code

### DIFF
--- a/drivers/trainbit/util.go
+++ b/drivers/trainbit/util.go
@@ -1,6 +1,7 @@
 package trainbit
 
 import (
+	"html"
 	"io"
 	"net/http"
 	"net/url"
@@ -95,6 +96,7 @@ func local2provider(filename string, isFolder bool) string {
 }
 
 func provider2local(filename string) string {
+	filename = html.UnescapeString(filename)
 	index := strings.LastIndex(filename, ".delete_suffix")
 	if index != -1 {
 		filename = filename[:index]


### PR DESCRIPTION
Trainbit返回文件名时会进行html编码，若不做处理会显示如`&amp;`等转义串