### PR TITLE
Fix there is no thumb when fs/get

### DIFF
--- a/server/handles/fsread.go
+++ b/server/handles/fsread.go
@@ -293,6 +293,7 @@ func FsGet(c *gin.Context) {
 		related = filterRelated(sameLevelFiles, obj)
 	}
 	parentMeta, _ := op.GetNearestMeta(parentPath)
+	thumb, _ := model.GetThumb(obj)
 	common.SuccessResp(c, FsGetResp{
 		ObjResp: ObjResp{
 			Name:     obj.GetName(),
@@ -301,6 +302,7 @@ func FsGet(c *gin.Context) {
 			Modified: obj.ModTime(),
 			Sign:     common.Sign(obj, parentPath, isEncrypt(meta, reqPath)),
 			Type:     utils.GetFileType(obj.GetName()),
+			Thumb:    thumb,
 		},
 		RawURL:   rawURL,
 		Readme:   getReadme(meta, reqPath),


### PR DESCRIPTION
When requesting api/fs/list, there is a thumb indeed, however, not in api/fs/get.
I don't know whether this is a bug or the author did this on demand.