### PR TITLE
fix(local): filename whitespace problem

### DIFF
--- a/drivers/local/driver.go
+++ b/drivers/local/driver.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	stdpath "path"
@@ -68,7 +67,7 @@ func (d *Local) GetAddition() driver.Additional {
 
 func (d *Local) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
 	fullPath := dir.GetPath()
-	rawFiles, err := ioutil.ReadDir(fullPath)
+	rawFiles, err := readDir(fullPath)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/local/util.go
+++ b/drivers/local/util.go
@@ -3,10 +3,12 @@ package local
 import (
 	"bytes"
 	"fmt"
-	ffmpeg "github.com/u2takey/ffmpeg-go"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+
+	ffmpeg "github.com/u2takey/ffmpeg-go"
 )
 
 func isSymlinkDir(f fs.FileInfo, path string) bool {
@@ -38,4 +40,18 @@ func GetSnapshot(videoPath string, frameNum int) (imgData *bytes.Buffer, err err
 		return nil, err
 	}
 	return srcBuf, nil
+}
+
+func readDir(dirname string) ([]fs.FileInfo, error) {
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+	list, err := f.Readdir(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].Name() < list[j].Name() })
+	return list, nil
 }

--- a/pkg/aria2/rpc/client.go
+++ b/pkg/aria2/rpc/client.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"time"
 )
 
@@ -89,7 +89,7 @@ func (c *client) AddURI(uris []string, options ...interface{}) (gid string, err 
 // If a file with the same name already exists, it is overwritten!
 // If the file cannot be saved successfully or --rpc-save-upload-metadata is false, the downloads added by this method are not saved by --save-session.
 func (c *client) AddTorrent(filename string, options ...interface{}) (gid string, err error) {
-	co, err := ioutil.ReadFile(filename)
+	co, err := os.ReadFile(filename)
 	if err != nil {
 		return
 	}
@@ -120,7 +120,7 @@ func (c *client) AddTorrent(filename string, options ...interface{}) (gid string
 // If a file with the same name already exists, it is overwritten!
 // If the file cannot be saved successfully or --rpc-save-upload-metadata is false, the downloads added by this method are not saved by --save-session.
 func (c *client) AddMetalink(filename string, options ...interface{}) (gid []string, err error) {
-	co, err := ioutil.ReadFile(filename)
+	co, err := os.ReadFile(filename)
 	if err != nil {
 		return
 	}

--- a/server/common/proxy.go
+++ b/server/common/proxy.go
@@ -61,7 +61,8 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.
 		if err != nil {
 			return err
 		}
-		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`, file.GetName(), url.QueryEscape(file.GetName())))
+		filename := file.GetName()
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`, filename, url.PathEscape(filename)))
 		http.ServeContent(w, r, file.GetName(), fileStat.ModTime(), f)
 		return nil
 	} else {

--- a/server/common/proxy.go
+++ b/server/common/proxy.go
@@ -3,7 +3,6 @@ package common
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -94,7 +93,7 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.
 		}
 		w.WriteHeader(res.StatusCode)
 		if res.StatusCode >= 400 {
-			all, _ := ioutil.ReadAll(res.Body)
+			all, _ := io.ReadAll(res.Body)
 			msg := string(all)
 			log.Debugln(msg)
 			return errors.New(msg)


### PR DESCRIPTION
修复本地文件驱动，文件名空格变成加号的问题
当初提交#3841 时没有发现本地驱动的处理逻辑有所不同