### PR TITLE
docs : Add description to mount path

### DIFF
--- a/internal/op/driver.go
+++ b/internal/op/driver.go
@@ -63,7 +63,7 @@ func getMainItems(config driver.Config) []driver.Item {
 		Name:     "mount_path",
 		Type:     conf.TypeString,
 		Required: true,
-		Help:     "The name displayed externally on the front end",
+		Help:     "The path you want to mount to, it is unique and cannot be repeated",
 	}, {
 		Name: "order",
 		Type: conf.TypeNumber,

--- a/internal/op/driver.go
+++ b/internal/op/driver.go
@@ -63,7 +63,7 @@ func getMainItems(config driver.Config) []driver.Item {
 		Name:     "mount_path",
 		Type:     conf.TypeString,
 		Required: true,
-		Help:     "",
+		Help:     "The name displayed externally on the front end",
 	}, {
 		Name: "order",
 		Type: conf.TypeNumber,


### PR DESCRIPTION
When filling in the mount path, many people will subconsciously fill in a duplicate
`Failed create storage in database: UNIQUE constraint failed: x_storages.mount_path`

Originally, I wanted to Chineseize the error message directly, but due to limited technology, I couldn’t directly Chineseize it.
**Maybe you can provide a similar case, I will study and then "try" to Chineseize some of the error prompts**

add:
![image](https://github.com/alist-org/alist/assets/56105412/736f7f50-28bc-4ef7-a30f-3fabd7dadd6b)
