### PR TITLE
feat: set content type from stream when uploading to s3

### DIFF
--- a/drivers/s3/driver.go
+++ b/drivers/s3/driver.go
@@ -136,11 +136,13 @@ func (d *S3) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreame
 		uploader.PartSize = stream.GetSize() / (s3manager.MaxUploadParts - 1)
 	}
 	key := getKey(stdpath.Join(dstDir.GetPath(), stream.GetName()), false)
+	contentType := stream.GetMimetype()
 	log.Debugln("key:", key)
 	input := &s3manager.UploadInput{
-		Bucket: &d.Bucket,
-		Key:    &key,
-		Body:   stream,
+		Bucket:      &d.Bucket,
+		Key:         &key,
+		Body:        stream,
+		ContentType: &contentType,
 	}
 	_, err := uploader.UploadWithContext(ctx, input)
 	return err


### PR DESCRIPTION
使用 s3 驱动上传时设置 `Content-Type`  为文件流的文件类型，以免 s3 使用默认的 `application/octet-stream`

Set the `Content-Type` param when uploading a file using s3 driver