### PR TITLE
fix(seafile): Seafile Driver 下载或上传文件时返回 500，后端 Driver Panic

### DIFF
--- a/drivers/seafile/util.go
+++ b/drivers/seafile/util.go
@@ -40,7 +40,8 @@ func (d *Seafile) request(method string, pathname string, callback base.ReqCallb
 	for i := 0; i < 2; i++ {
 		req.SetHeader("Authorization", d.authorization)
 		callback(req)
-		res, err := req.Execute(method, full)
+		localRes, err := req.Execute(method, full)
+		res = *localRes
 		if err != nil {
 			return nil, err
 		}

--- a/drivers/seafile/util.go
+++ b/drivers/seafile/util.go
@@ -36,12 +36,14 @@ func (d *Seafile) request(method string, pathname string, callback base.ReqCallb
 	if len(noRedirect) > 0 && noRedirect[0] {
 		req = base.NoRedirectClient.R()
 	}
-	var res resty.Response
+	req.SetHeader("Authorization", d.authorization)
+	callback(req)
+	var (
+		res *resty.Response
+		err error
+	)
 	for i := 0; i < 2; i++ {
-		req.SetHeader("Authorization", d.authorization)
-		callback(req)
-		localRes, err := req.Execute(method, full)
-		res = *localRes
+		res, err = req.Execute(method, full)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## 问题描述

Seafile Driver 下载或上传文件时返回 500，后端 Driver 日志记录 Panic。主要问题是由于局部的 `res` 未传出，导致 `res.Body()` 结果为空，后续去除 `"` 时失败。目前采用了最小改动，建议解析结果 URL 时也通过 `req.SetResult` 直接 Unmarshall JSON 字符串。

## 涉及版本

v3.17.0

## 复现步骤

1. 设置 Seafile 后端（我测试使用的是个人版）
2. 在前端点击某个文件进行下载或预览

## 问题截图

![image](https://github.com/alist-org/alist/assets/13360135/859c4fdd-b7bf-4d3d-8ed4-3a7dc658162c)

## 错误日志

```text
2023/05/28 03:34:51 [Recovery] 2023/05/28 - 03:34:51 panic recovered:
runtime error: slice bounds out of range [:-1]

runtime/debug.Stack()
        /usr/lib/go/src/runtime/debug/stack.go:24 +0x65
github.com/alist-org/alist/v3/pkg/singleflight.newPanicError({0x18fdc80?, 0xc0007c0ee8})
        /app/pkg/singleflight/singleflight.go:35 +0x2c
github.com/alist-org/alist/v3/pkg/singleflight.(*Group[...]).doCall.func2.1()
        /app/pkg/singleflight/singleflight.go:188 +0x3b
panic({0x18fdc80, 0xc0007c0ee8})
        /usr/lib/go/src/runtime/panic.go:884 +0x212
github.com/alist-org/alist/v3/drivers/seafile.(*Seafile).Link(0xc00043c280, {0x0?, 0x2d?}, {0x23c0f10, 0xc000462380}, {{0xc000755310, 0xe}, 0xc0008a15c0, {0x0, 0x0}})
        /app/drivers/seafile/driver.go:76 +0x19b
github.com/alist-org/alist/v3/internal/op.Link.func1()
        /app/internal/op/fs.go:251 +0x63
github.com/alist-org/alist/v3/pkg/singleflight.(*Group[...]).doCall.func2(0xc000752df6?, 0xc0001a6820, 0x7fd4293d5108)
        /app/pkg/singleflight/singleflight.go:193 +0x71
github.com/alist-org/alist/v3/pkg/singleflight.(*Group[...]).doCall(0xc000768d50?, 0xc0007fee40?, {0xc0007fee40?, 0x89763a?}, 0x23ae920?)
        /app/pkg/singleflight/singleflight.go:195 +0xb0
github.com/alist-org/alist/v3/pkg/singleflight.(*Group[...]).Do(0x2fcb7e0, {0xc0007fee40, 0x3c}, 0xc00072a8e3)
        /app/pkg/singleflight/singleflight.go:108 +0x176
github.com/alist-org/alist/v3/internal/op.Link({0x23bd050, 0xc000792100}, {0x23c5f48?, 0xc00043c280?}, {0xc00072a8e3, 0x1a}, {{0xc000755310, 0xe}, 0xc0008a15c0, {0x0, ...}})
        /app/internal/op/fs.go:260 +0x405
github.com/alist-org/alist/v3/internal/fs.link({0x23bd050?, 0xc000792100}, {0xc00072a8d0?, 0xc000755310?}, {{0xc000755310, 0xe}, 0xc0008a15c0, {0x0, 0x0}})
        /app/internal/fs/link.go:19 +0x138
github.com/alist-org/alist/v3/internal/fs.Link({0x23bd050?, 0xc000792100?}, {0xc00072a8d0, 0x2d}, {{0xc000755310, 0xe}, 0xc0008a15c0, {0x0, 0x0}})
        /app/internal/fs/fs.go:48 +0x6d
github.com/alist-org/alist/v3/server/handles.FsGet(0xc000792100)
        /app/server/handles/fsread.go:289 +0x7de
github.com/gin-gonic/gin.(*Context).Next(...)
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/context.go:174
github.com/alist-org/alist/v3/server/middlewares.Auth(0xc000792100)
        /app/server/middlewares/auth.go:67 +0x4e8
github.com/gin-gonic/gin.(*Context).Next(...)
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/context.go:174
github.com/alist-org/alist/v3/server/middlewares.StoragesLoaded(0xc000792100)
        /app/server/middlewares/check.go:14 +0x2ad
github.com/gin-gonic/gin.(*Context).Next(...)
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/context.go:174
github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1(0xc000792100)
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/recovery.go:102 +0x82
github.com/gin-gonic/gin.(*Context).Next(...)
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/context.go:174
github.com/gin-gonic/gin.LoggerWithConfig.func1(0xc000792100)
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/logger.go:240 +0xe7
github.com/gin-gonic/gin.(*Context).Next(...)
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/context.go:174
github.com/gin-gonic/gin.(*Engine).handleHTTPRequest(0xc000782680, 0xc000792100)
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/gin.go:620 +0x671
github.com/gin-gonic/gin.(*Engine).ServeHTTP(0xc000782680, {0x23ba500?, 0xc00072cc40}, 0xc000793800)
        /root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/gin.go:576 +0x1dd
net/http.serverHandler.ServeHTTP({0x23b57a8?}, {0x23ba500, 0xc00072cc40}, 0xc000793800)
        /usr/lib/go/src/net/http/server.go:2947 +0x30c
net/http.(*conn).serve(0xc0001214a0, {0x23bc7c8, 0xc0007e8450})
        /usr/lib/go/src/net/http/server.go:1991 +0x607
created by net/http.(*Server).Serve
        /usr/lib/go/src/net/http/server.go:3102 +0x4db

/app/pkg/singleflight/singleflight.go:165 (0x8851f2)
/app/pkg/singleflight/singleflight.go:200 (0x88a5ea)
/app/pkg/singleflight/singleflight.go:108 (0x88a3f5)
/app/internal/op/fs.go:260 (0x87b544)
/app/internal/fs/link.go:19 (0xd37557)
/app/internal/fs/fs.go:48 (0xd3640c)
/app/server/handles/fsread.go:289 (0x14ea17d)
/root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/context.go:174 (0x14a64c7)
/app/server/middlewares/auth.go:67 (0x14a62b4)
/root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/context.go:174 (0x14a69ec)
/app/server/middlewares/check.go:14 (0x14a6777)
/root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/context.go:174 (0xd27fe1)
/root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/recovery.go:102 (0xd27fcc)
/root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/context.go:174 (0xd270e6)
/root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/logger.go:240 (0xd270c9)
/root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/context.go:174 (0xd26170)
/root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/gin.go:620 (0xd25dd8)
/root/go/pkg/mod/github.com/gin-gonic/gin@v1.9.0/gin.go:576 (0xd2591c)
/usr/lib/go/src/net/http/server.go:2947 (0x73ef0b)
/usr/lib/go/src/net/http/server.go:1991 (0x73a126)
/usr/lib/go/src/runtime/asm_amd64.s:1594 (0x474f60)
```