### PR TITLE
feat(cloudreve): 自动移除服务器地址末尾的 "/"

### DIFF
--- a/drivers/cloudreve/driver.go
+++ b/drivers/cloudreve/driver.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
@@ -30,6 +31,8 @@ func (d *Cloudreve) Init(ctx context.Context) error {
 	if d.Cookie != "" {
 		return nil
 	}
+	// removing trailing slash
+	d.Address = strings.TrimSuffix(d.Address, "/")
 	return d.login()
 }
 

--- a/drivers/cloudreve/util.go
+++ b/drivers/cloudreve/util.go
@@ -21,7 +21,12 @@ import (
 const loginPath = "/user/session"
 
 func (d *Cloudreve) request(method string, path string, callback base.ReqCallback, out interface{}) error {
-	u := d.Address + "/api/v3" + path
+	baseUrl := d.Address
+	// removing trailing slash
+	if strings.HasSuffix(baseUrl, "/") {
+		baseUrl = baseUrl[:len(baseUrl)-1]
+	}
+	u := baseUrl + "/api/v3" + path
 	req := base.RestyClient.R()
 	req.SetHeaders(map[string]string{
 		"Cookie":     "cloudreve-session=" + d.Cookie,
@@ -57,7 +62,7 @@ func (d *Cloudreve) request(method string, path string, callback base.ReqCallbac
 				return d.request(method, path, callback, out)
 			}
 		}
-		
+
 		return errors.New(r.Msg)
 	}
 	sess := cookie.GetCookie(resp.Cookies(), "cloudreve-session")

--- a/drivers/cloudreve/util.go
+++ b/drivers/cloudreve/util.go
@@ -21,12 +21,7 @@ import (
 const loginPath = "/user/session"
 
 func (d *Cloudreve) request(method string, path string, callback base.ReqCallback, out interface{}) error {
-	baseUrl := d.Address
-	// removing trailing slash
-	if strings.HasSuffix(baseUrl, "/") {
-		baseUrl = baseUrl[:len(baseUrl)-1]
-	}
-	u := baseUrl + "/api/v3" + path
+	u := d.Address + "/api/v3" + path
 	req := base.RestyClient.R()
 	req.SetHeaders(map[string]string{
 		"Cookie":     "cloudreve-session=" + d.Cookie,


### PR DESCRIPTION
目前 Cloudreve 后端拼接请求 URL 的逻辑是 `d.Address + "/api/v3" + ...`，因此若设置服务器地址时包含了末尾 "/"，拼接后就会产生重复的 slashes。但是 Cloudreve 服务并不会自动解析去除掉多余的 slash，而是会直接 fallback 到默认的应用 HTML，并且状态码是 200。因此最终的现象就是：

- 前端文件夹内看不到任何内容
- 后端没有任何错误日志

由于观察不到任何问题相关的输出，因此排查起来较为困难。

## 复现步骤

1. 配置 v3.17.0 版本
2. 配置 Cloudreve Driver，在服务器地址处设置地址时包含末尾 "/"。如：`https://cloudreve.example.com/`
3. 在 AList 前端进入对应目录

## 截图

包含该 PR 前：

![image](https://github.com/alist-org/alist/assets/13360135/fbb5beb2-0c47-435f-894a-7d3fb7d138f8)

包含该 PR 后：

![image](https://github.com/alist-org/alist/assets/13360135/0f8268c3-f3d4-47f2-a38a-9b0f4bd77d6b)

## 日志

包含该 PR 前：

```text
[GIN] 2023/05/28 - 04:11:44 | 200 |     445.607µs |  101.94.139.222 | POST     "/api/fs/list"
[GIN] 2023/05/28 - 04:11:46 | 200 |  600.665164ms |  101.94.139.222 | POST     "/api/fs/list"
```

## 建议

相关 Driver 后端应该添加对返回结果是否符合预期的检查，如检查返回是否是 JSON，或者 Unmarshall 是否成功。
