### PR TITLE
feat: add proxy support for download

### DIFF
--- a/drivers/base/client.go
+++ b/drivers/base/client.go
@@ -42,6 +42,7 @@ func NewHttpClient() *http.Client {
 	return &http.Client{
 		Timeout: time.Hour * 48,
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: conf.Conf.TlsInsecureSkipVerify},
 		},
 	}


### PR DESCRIPTION
默认的 HTTPClient 没有配置 ProxyFromEnvironment，这导致在必须通过 proxy 访问互联网的环境无法使用。

而访问 api 使用的 resty 默认 transport 携带了 http.ProxyFromEnvironment，所以会发现目录可访问，文件无法下载。

