### PR TITLE
fix(lanzou): download not find data

### DIFF
--- a/drivers/lanzou/help.go
+++ b/drivers/lanzou/help.go
@@ -118,7 +118,19 @@ var findKVReg = regexp.MustCompile(`'(.+?)':('?([^' },]*)'?)`) // 拆分kv
 
 // 根据key查询js变量
 func findJSVarFunc(key, data string) string {
-	values := regexp.MustCompile(`var ` + key + ` = '(.+?)';`).FindStringSubmatch(data)
+	var values []string
+	if key != "sasign" {
+		values = regexp.MustCompile(`var ` + key + ` = '(.+?)';`).FindStringSubmatch(data)
+	} else {
+		matches := regexp.MustCompile(`var `+key+` = '(.+?)';`).FindAllStringSubmatch(data, -1)
+		if len(matches) == 3 {
+			values = matches[1]
+		} else {
+			if len(matches) > 0 {
+				values = matches[0]
+			}
+		}
+	}
 	if len(values) == 0 {
 		return ""
 	}

--- a/drivers/lanzou/util.go
+++ b/drivers/lanzou/util.go
@@ -374,7 +374,7 @@ func (d *LanZou) getFilesByShareUrl(shareID, pwd string, sharePageData string) (
 		if err != nil {
 			return nil, err
 		}
-		nextPageData := removeJSGlobalFunction(RemoveNotes(string(data)))
+		nextPageData := RemoveNotes(string(data))
 		param, err = htmlJsonToMap(nextPageData)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
故障：蓝奏云可以正常查看文件，但下载时报错：
```json
{
    "code": 500,
    "message": "failed link: failed get link: not find data",
    "data": null
}
```
猜测获取文件直链的逻辑已变化，此 PR 中修复了该问题

具体细节：
请求 `https://pan.lanzoui.com/fn?xxx` 现在的返回如下：
```html
<!-- file pages1 -->
<!DOCTYPE HTML>
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
<script type="text/javascript" src="https://assets.woozooo.com/assets/includes/js/jquery.js"></script>
<link href="https://assets.woozooo.com/assets/img/tf.css" rel="stylesheet" type="text/css">
</head>
<body>
<div id="outime">地址超时，请刷新</div>

<div class="load" id="tourl">
文件加载中...
</div>
<script type="text/javascript">
		var wsk_sign = 'c20230818';
		var aihidcms = '9AiH';
		var iucccjdsd = '';
		var ws_sign = 'c20230818';
		var sasign = 'xxxxxx';
		var ajaxdata = '?ctdf';
		//$.ajax({
			//type : 'post',
			//url : '/ajaxm.php',
			//b data : { 'action':'downprocess','signs':ajaxdata,'sign':'w},
			data : { 'action':'downprocess','signs':ajaxdata,'sign':sasign,'websign':iucccjdsd,'websignkey':aihidcms,'ves':1 },
			//b data : { 'action':'downprocess','signs':ajaxdata,'sign':'','websign':ws_sign,'websignkey':wsk_sign,'ves':1 },
			dataType : 'json',
	
		//});
</script>
<script type="text/javascript">

		var wsk_sign = 'c20230818';
		var aihidcms = '9AiH';
		var ciucjdsdc = '';
		var ws_sign = 'c20230818';
		var sasign = 'xxxxxx';
		var ajaxdata = '?ctdf';
		$.ajax({
			type : 'post',
			url : '/ajaxm.php',
			//b data : { 'action':'downprocess','signs':ajaxdata,'sign':'w},
			data : { 'action':'downprocess','signs':ajaxdata,'sign':sasign,'websign':ciucjdsdc,'websignkey':aihidcms,'ves':1 },
			//b data : { 'action':'downprocess','signs':ajaxdata,'sign':'','websign':ws_sign,'websignkey':wsk_sign,'ves':1 },
			dataType : 'json',
			success:function(msg){
				var date = msg;
				if(date.zt == '1'){
										$("#tourl").html("<a href="+date.dom+"/file/"+ date.url +" target=_blank rel=noreferrer><span class=txt>电信下载</span><span class='txt txtc'>联通下载</span><span class=txt>普通下载</span></a>");
					setTimeout('$("#outime").css("display","block");',1800000);
									}else{
					$("#tourl").html("网页超时，请刷新");
				};
				
			},
			error:function(){
				$("#tourl").html("获取失败，请刷新");
			}
	
		});
function woio2(){
		var wsk_sign = 'c20230818';
		var aihidcms = 'a ';
		var iucjdsd = ' c';
		var ws_sign = 'c20230818 ';
		var sasign = 'a a';
		var ajaxdata = 'cf';
		$.ajax({
			type : 'post',
			url : '/ajaxm.php',
			data : { 'action':'downprocess','sign':acidikaldka,'ves':1,'p':pwd },
			//data : { 'action':'downprocess','sign':'','ves':1,'p':pwd },
			dataType : 'json',
	
		});
}
</script>
</body>
</html>
```
其中，第二个 `<script type="text/javascript">` 中的 `sasign` 是有效的，而第一个中的 `sasign` 无效