### PR TITLE
feat(uss): add AntiTheftChainToken; fix link func

### DIFF
--- a/drivers/uss/driver.go
+++ b/drivers/uss/driver.go
@@ -80,7 +80,7 @@ func (d *USS) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*m
 	downExp := time.Hour * time.Duration(d.SignURLExpire)
 	expireAt := time.Now().Add(downExp).Unix()
 	upd := url.QueryEscape(path.Base(file.GetPath()))
-	signStr := strings.Join([]string{d.OperatorPassword, fmt.Sprint(expireAt), fmt.Sprintf("/%s", key)}, "&")
+	signStr := strings.Join([]string{d.AntiTheftChainToken, fmt.Sprint(expireAt), fmt.Sprintf("/%s", key)}, "&")
 	upt := utils.GetMD5EncodeStr(signStr)[12:20] + fmt.Sprint(expireAt)
 	link := fmt.Sprintf("%s?_upd=%s&_upt=%s", u, upd, upt)
 	return &model.Link{URL: link}, nil

--- a/drivers/uss/meta.go
+++ b/drivers/uss/meta.go
@@ -7,10 +7,11 @@ import (
 
 type Addition struct {
 	driver.RootPath
-	Bucket           string `json:"bucket" required:"true"`
-	Endpoint         string `json:"endpoint" required:"true"`
-	OperatorName     string `json:"operator_name" required:"true"`
-	OperatorPassword string `json:"operator_password" required:"true"`
+	Bucket              string `json:"bucket" required:"true"`
+	Endpoint            string `json:"endpoint" required:"true"`
+	OperatorName        string `json:"operator_name" required:"true"`
+	OperatorPassword    string `json:"operator_password" required:"true"`
+	AntiTheftChainToken string `json:"anti_theft_chain_token" required:"false" default:""`
 	//CustomHost       string `json:"custom_host"`	//Endpoint与CustomHost作用相同，去除
 	SignURLExpire int `json:"sign_url_expire" type:"number" default:"4"`
 }


### PR DESCRIPTION
故障: 参考之前的issue https://github.com/alist-org/alist/issues/4948 

当开启了又拍云的[时间戳防盗链](https://help.upyun.com/knowledge-base/cdn-token-limite/)之后，由于获取的连接的`_upt`参数错误，导致无法正常查看、下载文件。

经过查阅又拍云文档，目前的又拍云驱动获取链接的代码中，`_upt`参数的获取有问题，根据下图，获取的时候第一个参数应当是防盗链token，而不是操作员密码

![image](https://github.com/alist-org/alist/assets/96409857/f36453e4-ecb5-4cf0-b04a-38d66592b78f)

因此，添加了新的防盗链token参数，同时将获取`_upt`的代码从
`signStr := strings.Join([]string{d.OperatorPassword, fmt.Sprint(expireAt), fmt.Sprintf("/%s", key)}, "&")`
修改为
`signStr := strings.Join([]string{d.AntiTheftChainToken, fmt.Sprint(expireAt), fmt.Sprintf("/%s", key)}, "&")`

经过测试，现在开启防盗链后,设置了防盗链token就仍然可以正常查看和下载文件了。
![image](https://github.com/alist-org/alist/assets/96409857/10b87db3-217a-44c5-bcb4-28557d435bac)

