### PR TITLE
feat: crypt driver can load pre-generated thumbnails under the subdirectory

### DIFF
--- a/drivers/crypt/driver.go
+++ b/drivers/crypt/driver.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/alist-org/alist/v3/pkg/http_range"
 	"github.com/alist-org/alist/v3/pkg/utils"
+	"github.com/alist-org/alist/v3/server/common"
 	rcCrypt "github.com/rclone/rclone/backend/crypt"
 	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/config/obscure"
@@ -152,7 +153,10 @@ func (d *Crypt) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 				Ctime:    obj.CreateTime(),
 				// discarding hash as it's encrypted
 			}
-			if !ok {
+			if d.Thumbnail && thumb == "" {
+				thumb = utils.EncodePath(common.GetApiUrl(nil) + stdpath.Join("/d", args.ReqPath, ".thumbnails", name+".webp"), true)
+			}
+			if !ok && !d.Thumbnail {
 				result = append(result, &objRes)
 			} else {
 				objWithThumb := model.ObjThumb{

--- a/drivers/crypt/meta.go
+++ b/drivers/crypt/meta.go
@@ -19,6 +19,8 @@ type Addition struct {
 	Salt             string `json:"salt" confidential:"true"  help:"If you don't know what is salt, treat it as a second password. Optional but recommended"`
 	EncryptedSuffix  string `json:"encrypted_suffix" required:"true" default:".bin" help:"for advanced user only! encrypted files will have this suffix"`
 	FileNameEncoding string `json:"filename_encoding" type:"select" required:"true" options:"base64,base32,base32768" default:"base64" help:"for advanced user only!"`
+
+	Thumbnail   bool   `json:"thumbnail" required:"true" default:"false" help:"enable thumbnail which pre-generated under .thumbnails folder"`
 }
 
 var config = driver.Config{


### PR DESCRIPTION
When we set a crypt driver inside alist, all the files will be encrypted and stored inside the remote backend, and this means there is no useful thumbnails provided by the remote backend. This can be inconvenient when we have large video/image files stored in the cloud with end-to-end encryption because we can not peak the content of those encrypt files in both the remote backend and alist frontend.

This feature make sure the alist frontend can load the thumbnail for those large video/image files when the option is on and thumbnails pre-generated and uploaded to the same level sub-directory `.thumbnails`, e.g. file `/decrypt/A.mp4` have thumbnail file `/decrypt/.thumbnails/A.mp4.webp`, both the original file and thumbnail will be encrypted and uploaded the remote cloud storage, e.g file `/cloud/encrypted/A.mp4.bin` and `/cloud/encrypted/.thumbnails/A.mp4.webp`.

The thumbnail can be pre-generated offline with tools like `ffmpeg` and `convert`.