### PR TITLE
fix(terabox): encode parameters for `filemanager` api

### DIFF
--- a/drivers/terabox/util.go
+++ b/drivers/terabox/util.go
@@ -233,7 +233,7 @@ func (d *Terabox) manage(opera string, filelist interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	data := fmt.Sprintf("async=0&filelist=%s&ondup=newcopy", string(marshal))
+	data := fmt.Sprintf("async=0&filelist=%s&ondup=newcopy", encodeURIComponent(string(marshal)))
 	return d.post("/api/filemanager", params, data, nil)
 }
 


### PR DESCRIPTION
否则名称形如`1+1`的文件无法重命名、移动、删除等