### PR TITLE
perf(webdav): support for cookies on webdav drive

### DIFF
--- a/drivers/webdav/util.go
+++ b/drivers/webdav/util.go
@@ -2,6 +2,7 @@ package webdav
 
 import (
 	"net/http"
+	"net/http/cookiejar"
 
 	"github.com/alist-org/alist/v3/drivers/webdav/odrvcookie"
 	"github.com/alist-org/alist/v3/internal/model"
@@ -23,6 +24,13 @@ func (d *WebDav) setClient() error {
 				rq.Header.Del("Authorization")
 				rq.Header.Set("Cookie", cookie)
 			})
+		} else {
+			return err
+		}
+	} else {
+		cookieJar, err := cookiejar.New(nil)
+		if err == nil {
+			c.SetJar(cookieJar)
 		} else {
 			return err
 		}

--- a/pkg/gowebdav/client.go
+++ b/pkg/gowebdav/client.go
@@ -83,6 +83,11 @@ func (c *Client) SetTransport(transport http.RoundTripper) {
 	c.c.Transport = transport
 }
 
+// SetJar exposes the ability to set a cookie jar to the client.
+func (c *Client) SetJar(jar http.CookieJar) {
+	c.c.Jar = jar
+}
+
 // Connect connects to our dav server
 func (c *Client) Connect() error {
 	rs, err := c.options("/")
@@ -351,6 +356,11 @@ func (c *Client) Link(path string) (string, http.Header, error) {
 		return "", nil, newPathErrorErr("Link", path, err)
 	}
 
+	if c.c.Jar != nil {
+		for _, cookie := range c.c.Jar.Cookies(r.URL) {
+			r.AddCookie(cookie)
+		}
+	}
 	for k, vals := range c.headers {
 		for _, v := range vals {
 			r.Header.Add(k, v)


### PR DESCRIPTION
Some webdav servers, such as Nextcloud, are much faster when using cookies for authentication after the initial authentication, compared to re-authenticating with each request.

some tests:
Without using cookies, each request on my machine takes about 2 seconds.
![1697514177534](https://github.com/alist-org/alist/assets/8317478/13ae9bba-e5b9-4ecc-a986-7b86d36c3b29)

When using cookies, each request after basic authentication takes approximately 200-400 milliseconds.
![1697514366176](https://github.com/alist-org/alist/assets/8317478/2daa2a2f-a20f-47d0-9861-8e699ce5f497)

