### PR TITLE
add show hidden option for crypt storage

### DIFF
--- a/drivers/crypt/driver.go
+++ b/drivers/crypt/driver.go
@@ -124,6 +124,9 @@ func (d *Crypt) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 				//filter illegal files
 				continue
 			}
+			if !d.ShowHidden && strings.HasPrefix(name, ".") {
+				continue
+			}
 			objRes := model.Object{
 				Name:     name,
 				Size:     0,
@@ -143,6 +146,9 @@ func (d *Crypt) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 			name, err := d.cipher.DecryptFileName(obj.GetName())
 			if err != nil {
 				//filter illegal files
+				continue
+			}
+			if !d.ShowHidden && strings.HasPrefix(name, ".") {
 				continue
 			}
 			objRes := model.Object{

--- a/drivers/crypt/meta.go
+++ b/drivers/crypt/meta.go
@@ -21,6 +21,8 @@ type Addition struct {
 	FileNameEncoding string `json:"filename_encoding" type:"select" required:"true" options:"base64,base32,base32768" default:"base64" help:"for advanced user only!"`
 
 	Thumbnail   bool   `json:"thumbnail" required:"true" default:"false" help:"enable thumbnail which pre-generated under .thumbnails folder"`
+
+	ShowHidden       bool   `json:"show_hidden"  default:"true" required:"false" help:"show hidden directories and files"`
 }
 
 var config = driver.Config{


### PR DESCRIPTION
I tried adding a show hidden option for Crypt Storage. 
This is like the option to show files or directories that start with dot in Local Storage.
This is for directories that don't need to be visible to certain users.
I think it requires a .json file by running the alist lang command, but I don't know the exact workflow, so I'm just implementing the feature and submitting it.
Please confirm.
