### PR TITLE
add error handling for webdav mkcol according to RFC 4918

### DIFF
--- a/server/webdav/webdav.go
+++ b/server/webdav/webdav.go
@@ -382,6 +382,21 @@ func (h *Handler) handleMkcol(w http.ResponseWriter, r *http.Request) (status in
 	if r.ContentLength > 0 {
 		return http.StatusUnsupportedMediaType, nil
 	}
+
+	// RFC 4918 8.3.2
+	//405 (Method Not Allowed) - MKCOL can only be executed on an unmapped URL
+	if _, err := fs.Get(ctx, reqPath, &fs.GetArgs{}); err == nil {
+		return http.StatusMethodNotAllowed, err
+	}
+	// RFC 4918 9.3.1
+	// 409 (Conflict) The server MUST NOT create those intermediate collections automatically.
+	reqDir := path.Dir(reqPath)
+	if _, err := fs.Get(ctx, reqDir, &fs.GetArgs{}); err != nil {
+		if errs.IsObjectNotFound(err) {
+			return http.StatusConflict, err
+		}
+		return http.StatusMethodNotAllowed, err
+	}
 	if err := fs.MakeDir(ctx, reqPath); err != nil {
 		if os.IsNotExist(err) {
 			return http.StatusConflict, err

--- a/server/webdav/webdav.go
+++ b/server/webdav/webdav.go
@@ -383,7 +383,7 @@ func (h *Handler) handleMkcol(w http.ResponseWriter, r *http.Request) (status in
 		return http.StatusUnsupportedMediaType, nil
 	}
 
-	// RFC 4918 8.3.2
+	// RFC 4918 9.3.1
 	//405 (Method Not Allowed) - MKCOL can only be executed on an unmapped URL
 	if _, err := fs.Get(ctx, reqPath, &fs.GetArgs{}); err == nil {
 		return http.StatusMethodNotAllowed, err

--- a/server/webdav/webdav.go
+++ b/server/webdav/webdav.go
@@ -536,12 +536,12 @@ func (h *Handler) handleLock(w http.ResponseWriter, r *http.Request) (retStatus 
 			}
 		}
 		reqPath, status, err := h.stripPrefix(r.URL.Path)
+		if err != nil {
+			return status, err
+		}
 		reqPath, err = user.JoinPath(reqPath)
 		if err != nil {
 			return 403, err
-		}
-		if err != nil {
-			return status, err
 		}
 		ld = LockDetails{
 			Root:      reqPath,


### PR DESCRIPTION

Refer to #5491 使用litmus进行检测，当前版本结果:
![image](https://github.com/alist-org/alist/assets/96409857/9be94030-875f-4feb-bbdf-c05a17c1ea11)

参考[RFC 4918](https://datatracker.ietf.org/doc/html/rfc4918)
1. 根据RFC 4918 9.3.1: `405 (Method Not Allowed) - MKCOL can only be executed on an unmapped URL`
2. 根据RFC 4918 9.3.1: `409 (Conflict) The server MUST NOT create those intermediate collections automatically`

根据如上两条，添加了对应的error handling代码，修改后检测结果如下：
![image](https://github.com/alist-org/alist/assets/96409857/f681e75c-e67a-4043-9024-08d221691636)

另外，修改了`webdav.go`中`handleLock`函数的一段错误处理代码，原为:
```go
reqPath, status, err := h.stripPrefix(r.URL.Path)
reqPath, err = user.JoinPath(reqPath)
if err != nil {
   return 403, err
}
if err != nil {
  return status, err
}
```

第二个if判断永远不会有机会执行到，修改为:
```go
reqPath, status, err := h.stripPrefix(r.URL.Path)
if err != nil {
	return status, err
}
reqPath, err = user.JoinPath(reqPath)
if err != nil {
	return 403, err
}
```