### PR TITLE
feat(alias): add ability to set file alias

### DIFF
--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -79,7 +79,7 @@ func (d *Alias) Get(ctx context.Context, path string) (model.Obj, error) {
 func (d *Alias) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
 	path := dir.GetPath()
 	if utils.PathEqual(path, "/") && !d.autoFlatten {
-		return d.listRoot(), nil
+		return d.listRoot(ctx), nil
 	}
 	root, sub := d.getRootAndPath(path)
 	dsts, ok := d.pathMap[root]

--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/internal/fs"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/pkg/utils"
 )
@@ -41,10 +42,16 @@ func (d *Alias) Init(ctx context.Context) error {
 		d.pathMap[k] = append(d.pathMap[k], v)
 	}
 	if len(d.pathMap) == 1 {
-		for k := range d.pathMap {
+		for k, v := range d.pathMap {
 			d.oneKey = k
+			d.autoFlatten = true
+			if len(v) == 1 {
+				sourceObj, err := fs.Get(ctx, v[0], &fs.GetArgs{NoLog: true})
+				if err == nil && !sourceObj.IsDir() {
+					d.autoFlatten = false
+				}
+			}
 		}
-		d.autoFlatten = true
 	}
 	return nil
 }

--- a/drivers/local/driver.go
+++ b/drivers/local/driver.go
@@ -170,7 +170,7 @@ func (d *Local) Get(ctx context.Context, path string) (model.Obj, error) {
 		}
 		return &file, nil
 	}
-	return d.FileInfoToObj(f, d.MountPath, path), nil
+	return d.FileInfoToObj(f, d.MountPath, d.GetRootPath()), nil
 }
 
 func (d *Local) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {

--- a/drivers/local/driver.go
+++ b/drivers/local/driver.go
@@ -152,10 +152,6 @@ func (d *Local) Get(ctx context.Context, path string) (model.Obj, error) {
 		return nil, err
 	}
 	isFolder := f.IsDir() || isSymlinkDir(f, path)
-	size := f.Size()
-	if isFolder {
-		size = 0
-	}
 	var ctime time.Time
 	t, err := times.Stat(path)
 	if err == nil {
@@ -163,15 +159,18 @@ func (d *Local) Get(ctx context.Context, path string) (model.Obj, error) {
 			ctime = t.BirthTime()
 		}
 	}
-	file := model.Object{
-		Path:     path,
-		Name:     f.Name(),
-		Modified: f.ModTime(),
-		Ctime:    ctime,
-		Size:     size,
-		IsFolder: isFolder,
+	if isFolder {
+		file := model.Object{
+			Path:     path,
+			Name:     f.Name(),
+			Modified: f.ModTime(),
+			Ctime:    ctime,
+			Size:     0,
+			IsFolder: true,
+		}
+		return &file, nil
 	}
-	return &file, nil
+	return d.FileInfoToObj(f, d.MountPath, path), nil
 }
 
 func (d *Local) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {

--- a/server/handles/fsread.go
+++ b/server/handles/fsread.go
@@ -323,7 +323,7 @@ func FsGet(c *gin.Context) {
 	}
 	parentMeta, _ := op.GetNearestMeta(parentPath)
 	thumb, _ := model.GetThumb(obj)
-	common.SuccessResp(c, FsGetResp{
+	fsresp := FsGetResp{
 		ObjResp: ObjResp{
 			Name:        obj.GetName(),
 			Size:        obj.GetSize(),
@@ -332,7 +332,6 @@ func FsGet(c *gin.Context) {
 			Created:     obj.CreateTime(),
 			HashInfoStr: obj.GetHash().String(),
 			HashInfo:    obj.GetHash().Export(),
-			Sign:        common.Sign(obj, parentPath, isEncrypt(meta, reqPath)),
 			Type:        utils.GetFileType(obj.GetName()),
 			Thumb:       thumb,
 		},
@@ -341,7 +340,14 @@ func FsGet(c *gin.Context) {
 		Header:   getHeader(meta, reqPath),
 		Provider: provider,
 		Related:  toObjsResp(related, parentPath, isEncrypt(parentMeta, parentPath)),
-	})
+	}
+	if provider == "Alias" {
+		fsresp.Name = stdpath.Base(reqPath)
+		fsresp.Sign = sign.Sign(reqPath)
+	} else {
+		fsresp.Sign = common.Sign(obj, parentPath, isEncrypt(meta, reqPath))
+	}
+	common.SuccessResp(c, fsresp)
 }
 
 func filterRelated(objs []model.Obj, obj model.Obj) []model.Obj {


### PR DESCRIPTION
以以下几个alias测试：
sample1.png:/local/sample1.png
sample2.png:/s3/sample2.png
sample3.png:/od/sample3.jpg
all:/local/
all:/local1/
前三个为文件别名，后两个为之前的文件夹合并别名，功能均正常。其他暂未测试
