### PR TITLE
fix FsStream no http body

### DIFF
--- a/server/handles/fsup.go
+++ b/server/handles/fsup.go
@@ -3,7 +3,9 @@ package handles
 import (
 	"github.com/xhofe/tache"
 	"io"
+	"net/http"
 	"net/url"
+	"os"
 	stdpath "path"
 	"strconv"
 	"time"
@@ -58,6 +60,17 @@ func FsStream(c *gin.Context) {
 		Mimetype:     c.GetHeader("Content-Type"),
 		WebPutAsTask: asTask,
 	}
+
+	if c.Request.Body == http.NoBody {
+		f, err := os.Open(path)
+		if err != nil {
+			common.ErrorResp(c, err, 400)
+			return
+		}
+		defer func() { _ = f.Close() }()
+		s.Reader = struct{ io.Reader }{f}
+	}
+
 	var t tache.TaskWithInfo
 	if asTask {
 		t, err = fs.PutAsTask(dir, s)


### PR DESCRIPTION
curl 'http://127.0.0.1:5244/api/fs/put' \
  -X 'PUT' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: zh-CN,zh;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Content-Length: 0' \
  -H 'File-Path: %2FUsers%2Fkazhang%2FDesktop%2F1.md' \
  -H 'Origin: http://127.0.0.1:5244' \
  -H 'Password;' \
  -H 'Referer: http://127.0.0.1:5244/' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36' \
  -H 'sec-ch-ua: "Google Chrome";v="119", "Chromium";v="119", "Not?A_Brand";v="24"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  --compressed

this put api  c.Request.Body  is  http.NoBody , open file fill reader can fix 