### PR TITLE
fix(chaoxing):fix JSON parsing error in `content` field

### DIFF
--- a/drivers/chaoxing/types.go
+++ b/drivers/chaoxing/types.go
@@ -1,7 +1,7 @@
 package chaoxing
 
 import (
-	"encoding/json"
+	"bytes"
 	"fmt"
 	"strconv"
 	"time"
@@ -95,23 +95,13 @@ type UserAuth struct {
 // 手机端json `"puid": "54321". "size": "12345"`
 type int_str int
 
-// UnmarshalJSON 实现 json.Unmarshaler 接口
+// json 字符串数字和纯数字解析
 func (ios *int_str) UnmarshalJSON(data []byte) error {
-	// 解析为int
-	var intValue int
-	if err := json.Unmarshal(data, &intValue); err == nil {
-		*ios = int_str(intValue)
-		return nil
+	intValue, err := strconv.Atoi(string(bytes.Trim(data, "\"")))
+	if err != nil {
+		return err
 	}
-	// 解析string再转int
-	var strValue string
-	if err := json.Unmarshal(data, &strValue); err == nil {
-		intValue, err := strconv.Atoi(strValue)
-		if err != nil {
-			return fmt.Errorf("json: cannot unmarshal data into Go struct field .list.content._ of type int_string")
-		}
-		*ios = int_str(intValue)
-	}
+	*ios = int_str(intValue)
 	return nil
 }
 

--- a/drivers/chaoxing/types.go
+++ b/drivers/chaoxing/types.go
@@ -1,7 +1,9 @@
 package chaoxing
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/alist-org/alist/v3/internal/model"
@@ -88,44 +90,69 @@ type UserAuth struct {
 	} `json:"operationAuth"`
 }
 
+// 手机端学习通上传的文件的json内容(content字段)与网页端上传的有所不同
+// 网页端json `"puid": 54321, "size": 12345`
+// 手机端json `"puid": "54321". "size": "12345"`
+type int_str int
+
+// UnmarshalJSON 实现 json.Unmarshaler 接口
+func (ios *int_str) UnmarshalJSON(data []byte) error {
+	// 解析为int
+	var intValue int
+	if err := json.Unmarshal(data, &intValue); err == nil {
+		*ios = int_str(intValue)
+		return nil
+	}
+	// 解析string再转int
+	var strValue string
+	if err := json.Unmarshal(data, &strValue); err == nil {
+		intValue, err := strconv.Atoi(strValue)
+		if err != nil {
+			return fmt.Errorf("json: cannot unmarshal data into Go struct field .list.content._ of type int_string")
+		}
+		*ios = int_str(intValue)
+	}
+	return nil
+}
+
 type File struct {
 	Cataid  int `json:"cataid"`
 	Cfid    int `json:"cfid"`
 	Content struct {
-		Cfid             int    `json:"cfid"`
-		Pid              int    `json:"pid"`
-		FolderName       string `json:"folderName"`
-		ShareType        int    `json:"shareType"`
-		Preview          string `json:"preview"`
-		Filetype         string `json:"filetype"`
-		PreviewURL       string `json:"previewUrl"`
-		IsImg            bool   `json:"isImg"`
-		ParentPath       string `json:"parentPath"`
-		Icon             string `json:"icon"`
-		Suffix           string `json:"suffix"`
-		Duration         int    `json:"duration"`
-		Pantype          string `json:"pantype"`
-		Puid             int    `json:"puid"`
-		Filepath         string `json:"filepath"`
-		Crc              string `json:"crc"`
-		Isfile           bool   `json:"isfile"`
-		Residstr         string `json:"residstr"`
-		ObjectID         string `json:"objectId"`
-		Extinfo          string `json:"extinfo"`
-		Thumbnail        string `json:"thumbnail"`
-		Creator          int    `json:"creator"`
-		ResTypeValue     int    `json:"resTypeValue"`
-		UploadDateFormat string `json:"uploadDateFormat"`
-		DisableOpt       bool   `json:"disableOpt"`
-		DownPath         string `json:"downPath"`
-		Sort             int    `json:"sort"`
-		Topsort          int    `json:"topsort"`
-		Restype          string `json:"restype"`
-		Size             int    `json:"size"`
-		UploadDate       string `json:"uploadDate"`
-		FileSize         string `json:"fileSize"`
-		Name             string `json:"name"`
-		FileID           string `json:"fileId"`
+		Cfid             int     `json:"cfid"`
+		Pid              int     `json:"pid"`
+		FolderName       string  `json:"folderName"`
+		ShareType        int     `json:"shareType"`
+		Preview          string  `json:"preview"`
+		Filetype         string  `json:"filetype"`
+		PreviewURL       string  `json:"previewUrl"`
+		IsImg            bool    `json:"isImg"`
+		ParentPath       string  `json:"parentPath"`
+		Icon             string  `json:"icon"`
+		Suffix           string  `json:"suffix"`
+		Duration         int     `json:"duration"`
+		Pantype          string  `json:"pantype"`
+		Puid             int_str `json:"puid"`
+		Filepath         string  `json:"filepath"`
+		Crc              string  `json:"crc"`
+		Isfile           bool    `json:"isfile"`
+		Residstr         string  `json:"residstr"`
+		ObjectID         string  `json:"objectId"`
+		Extinfo          string  `json:"extinfo"`
+		Thumbnail        string  `json:"thumbnail"`
+		Creator          int     `json:"creator"`
+		ResTypeValue     int     `json:"resTypeValue"`
+		UploadDateFormat string  `json:"uploadDateFormat"`
+		DisableOpt       bool    `json:"disableOpt"`
+		DownPath         string  `json:"downPath"`
+		Sort             int     `json:"sort"`
+		Topsort          int     `json:"topsort"`
+		Restype          string  `json:"restype"`
+		Size             int_str `json:"size"`
+		UploadDate       string  `json:"uploadDate"`
+		FileSize         string  `json:"fileSize"`
+		Name             string  `json:"name"`
+		FileID           string  `json:"fileId"`
 	} `json:"content"`
 	CreatorID  int    `json:"creatorId"`
 	DesID      string `json:"des_id"`
@@ -203,7 +230,6 @@ type UploadFileDataRsp struct {
 		Extinfo          string    `json:"extinfo"`
 	} `json:"data"`
 }
-
 
 type UploadDoneParam struct {
 	Cataid string `json:"cataid"`

--- a/drivers/chaoxing/util.go
+++ b/drivers/chaoxing/util.go
@@ -79,7 +79,7 @@ func (d *ChaoXing) GetFiles(parent string) ([]File, error) {
 		return nil, err
 	}
 	if resp.Result != 1 {
-		msg:=fmt.Sprintf("error code is:%d", resp.Result)
+		msg := fmt.Sprintf("error code is:%d", resp.Result)
 		return nil, errors.New(msg)
 	}
 	if len(resp.List) > 0 {
@@ -97,8 +97,12 @@ func (d *ChaoXing) GetFiles(parent string) ([]File, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(resps.List) > 0 {
-		files = append(files, resps.List...)
+	for _, file := range resps.List {
+		// 手机端超星上传的文件没有fileID字段，但ObjectID与fileID相同，可代替
+		if file.Content.FileID == "" {
+			file.Content.FileID = file.Content.ObjectID
+		}
+		files = append(files, file)
 	}
 	return files, nil
 }


### PR DESCRIPTION
手机端超星上传小组云盘和网页端上传的文件在获取文件信息（`pc/resource/getResourceList&recType=2`）时返回的 json 格式不同，`size` 和 `puid` 字段可能是 string 也可能是 int。

用自定义数据类型 `int_str` 和 `unmarshaler` 接口来解决此问题。