### PR TITLE
fix(google_photo): add support for streaming video, range requests

### DIFF
--- a/drivers/google_photo/driver.go
+++ b/drivers/google_photo/driver.go
@@ -58,9 +58,33 @@ func (d *GooglePhoto) Link(ctx context.Context, file model.Obj, args model.LinkA
 			URL: f.BaseURL + "=d",
 		}, nil
 	} else if strings.Contains(f.MimeType, "video/") {
-		return &model.Link{
-			URL: f.BaseURL + "=dv",
-		}, nil
+		var width, height int
+
+		fmt.Sscanf(f.MediaMetadata.Width, "%d", &width)
+		fmt.Sscanf(f.MediaMetadata.Height, "%d", &height)
+
+		switch {
+		// 1080P
+		case width == 1920 && height == 1080:
+			return &model.Link{
+				URL: f.BaseURL + "=m37",
+			}, nil
+		// 720P
+		case width == 1280 && height == 720:
+			return &model.Link{
+				URL: f.BaseURL + "=m22",
+			}, nil
+		// 360P
+		case width == 640 && height == 360:
+			return &model.Link{
+				URL: f.BaseURL + "=m18",
+			}, nil
+		default:
+			return &model.Link{
+				URL: f.BaseURL + "=dv",
+			}, nil
+		}
+
 	}
 	return &model.Link{}, nil
 }

--- a/drivers/google_photo/util.go
+++ b/drivers/google_photo/util.go
@@ -151,7 +151,7 @@ func (d *GooglePhoto) getMedia(id string) (MediaItem, error) {
 	var resp MediaItem
 
 	query := map[string]string{
-		"fields": "baseUrl,mimeType",
+		"fields": "mediaMetadata,baseUrl,mimeType",
 	}
 	_, err := d.request(fmt.Sprintf("https://photoslibrary.googleapis.com/v1/mediaItems/%s", id), http.MethodGet, func(req *resty.Request) {
 		req.SetQueryParams(query)


### PR DESCRIPTION
`=dv`的参数获取的视频不支持流式传输，但`=m37`这种指定转码分辨率参数获取的视频是支持的。
添加了通过`mediaMetadata`中的长宽来判断分辨率。
`1080p`添加`=m37`;
`720p`添加`=m22`;
`360p`添加`=m18`;
非上述三种分辨率的标准长宽情况则默认为`=dv`.

关联issue:
- #5703 