### PR TITLE
fix(quqi): error returned when uploading a file that existed

### DIFF
--- a/drivers/quqi/types.go
+++ b/drivers/quqi/types.go
@@ -133,6 +133,9 @@ type UploadInitResp struct {
 		Token    string `json:"token"`
 		UploadID string `json:"upload_id"`
 		URL      string `json:"url"`
+		NodeID   int64  `json:"node_id"`
+		NodeName string `json:"node_name"`
+		ParentID int64  `json:"parent_id"`
 	} `json:"data"`
 	Err int    `json:"err"`
 	Msg string `json:"msg"`

--- a/drivers/quqi/util.go
+++ b/drivers/quqi/util.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	stdpath "path"
 	"strings"
 
 	"github.com/alist-org/alist/v3/drivers/base"
@@ -96,4 +97,14 @@ func (d *Quqi) checkLogin() bool {
 		return false
 	}
 	return true
+}
+
+// rawExt 保留扩展名大小写
+func rawExt(name string) string {
+	ext := stdpath.Ext(name)
+	if strings.HasPrefix(ext, ".") {
+		ext = ext[1:]
+	}
+
+	return ext
 }


### PR DESCRIPTION
上传文件时，若曲奇云端存在相同的文件信息摘要(md5/sha)，则不必进行实际上传，曲奇会自动创建或恢复文件；`/api/upload/v1/file/init`接口会返回文件的`node_id` `node_name` `parent_id`，且`exist`为true，并不再返回上传接口的token

以下为两种不同情况下的`/api/upload/v1/file/init`接口响应
- 曲奇云端已存在：
![1705728329986](https://github.com/alist-org/alist/assets/32877980/f0f7e589-340d-4e99-8728-31dfe79ee961)
- 曲奇云端不存在：
![1705728464537](https://github.com/alist-org/alist/assets/32877980/ac80680e-e34a-40a3-9c62-aacb857fb0c9)
