### PR TITLE
fix(quqi): empty file link for no vip user

### DIFF
--- a/drivers/quqi/types.go
+++ b/drivers/quqi/types.go
@@ -133,6 +133,9 @@ type UploadInitResp struct {
 		Token    string `json:"token"`
 		UploadID string `json:"upload_id"`
 		URL      string `json:"url"`
+		NodeID   int64  `json:"node_id"`
+		NodeName string `json:"node_name"`
+		ParentID int64  `json:"parent_id"`
 	} `json:"data"`
 	Err int    `json:"err"`
 	Msg string `json:"msg"`

--- a/drivers/quqi/types.go
+++ b/drivers/quqi/types.go
@@ -31,6 +31,13 @@ type GetDocRes struct {
 	} `json:"data"`
 }
 
+type GetDownloadResp struct {
+	BaseRes
+	Data struct {
+		Url string `json:"url"`
+	} `json:"data"`
+}
+
 type MakeDirRes struct {
 	BaseRes
 	Data struct {

--- a/drivers/quqi/util.go
+++ b/drivers/quqi/util.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	stdpath "path"
 	"strings"
 
 	"github.com/alist-org/alist/v3/drivers/base"
@@ -96,4 +97,14 @@ func (d *Quqi) checkLogin() bool {
 		return false
 	}
 	return true
+}
+
+// rawExt 保留扩展名大小写
+func rawExt(name string) string {
+	ext := stdpath.Ext(name)
+	if strings.HasPrefix(ext, ".") {
+		ext = ext[1:]
+	}
+
+	return ext
 }

--- a/drivers/quqi/util.go
+++ b/drivers/quqi/util.go
@@ -32,7 +32,7 @@ func (d *Quqi) request(host string, path string, method string, callback base.Re
 	req.SetHeaders(map[string]string{
 		"Origin": "https://quqi.com",
 		"Cookie": d.Cookie,
-	}).SetResult(&result)
+	})
 
 	if d.GroupID != "" {
 		req.SetQueryParam("quqiid", d.GroupID)
@@ -43,6 +43,11 @@ func (d *Quqi) request(host string, path string, method string, callback base.Re
 	}
 
 	res, err := req.Execute(method, reqUrl.String())
+	if err != nil {
+		return nil, err
+	}
+	// resty.Request.SetResult cannot parse result correctly sometimes
+	err = utils.Json.Unmarshal(res.Body(), &result)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
曲奇资源链接分为下载链接和预览链接，非VIP用户无法获取媒体资源文件(视频/图片等)的预览链接，只能获取下载链接

解决方案：先从`/api/doc/getDoc`接口获取预览链接，若无法获取则从`/api/doc/getDownload`接口获取下载链接。经过初步测试，预览链接的内容下载速度会比下载链接的快。

限制：非VIP用户同时下载的资源数量存在限制，超过限制后一定时间内禁止下载