### PR TITLE
feat(dropbox): add root_namespace_id to access teams folder

### DIFF
--- a/drivers/dropbox/driver.go
+++ b/drivers/dropbox/driver.go
@@ -45,7 +45,20 @@ func (d *Dropbox) Init(ctx context.Context) error {
 	if result != query {
 		return fmt.Errorf("failed to check user: %s", string(res))
 	}
-	return nil
+	d.RootNamespaceId, err = d.GetRootNamespaceId(ctx)
+
+	return err
+}
+
+func (d *Dropbox) GetRootNamespaceId(ctx context.Context) (string, error) {
+	res, err := d.request("/2/users/get_current_account", http.MethodPost, func(req *resty.Request) {
+		req.SetContext(ctx)
+	})
+	if err != nil {
+		return "", err
+	}
+	rootNamespaceID := utils.Json.Get(res, "root_info.root_namespace_id").ToString()
+	return rootNamespaceID, nil
 }
 
 func (d *Dropbox) Drop(ctx context.Context) error {

--- a/drivers/dropbox/driver.go
+++ b/drivers/dropbox/driver.go
@@ -57,8 +57,13 @@ func (d *Dropbox) GetRootNamespaceId(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	rootNamespaceID := utils.Json.Get(res, "root_info.root_namespace_id").ToString()
-	return rootNamespaceID, nil
+	var currentAccountResp CurrentAccountResp
+	err = utils.Json.Unmarshal(res, &currentAccountResp)
+	if err != nil {
+		return "", err
+	}
+	rootNamespaceId := currentAccountResp.RootInfo.RootNamespaceId
+	return rootNamespaceId, nil
 }
 
 func (d *Dropbox) Drop(ctx context.Context) error {

--- a/drivers/dropbox/driver.go
+++ b/drivers/dropbox/driver.go
@@ -52,7 +52,7 @@ func (d *Dropbox) Init(ctx context.Context) error {
 
 func (d *Dropbox) GetRootNamespaceId(ctx context.Context) (string, error) {
 	res, err := d.request("/2/users/get_current_account", http.MethodPost, func(req *resty.Request) {
-		req.SetContext(ctx)
+		req.SetBody(nil)
 	})
 	if err != nil {
 		return "", err

--- a/drivers/dropbox/meta.go
+++ b/drivers/dropbox/meta.go
@@ -18,6 +18,7 @@ type Addition struct {
 	ClientSecret  string `json:"client_secret" required:"false" help:"Keep it empty if you don't have one"`
 
 	AccessToken string
+	RootNamespaceId string
 }
 
 var config = driver.Config{

--- a/drivers/dropbox/meta.go
+++ b/drivers/dropbox/meta.go
@@ -17,7 +17,7 @@ type Addition struct {
 	ClientID      string `json:"client_id" required:"false" help:"Keep it empty if you don't have one"`
 	ClientSecret  string `json:"client_secret" required:"false" help:"Keep it empty if you don't have one"`
 
-	AccessToken string
+	AccessToken     string
 	RootNamespaceId string
 }
 

--- a/drivers/dropbox/types.go
+++ b/drivers/dropbox/types.go
@@ -23,6 +23,13 @@ type RefreshTokenErrorResp struct {
 	ErrorDescription string `json:"error_description"`
 }
 
+type CurrentAccountResp struct {
+	RootInfo struct {
+		RootNamespaceId string `json:"root_namespace_id"`
+		HomeNamespaceId string `json:"home_namespace_id"`
+	} `json:"root_info"`
+}
+
 type File struct {
 	Tag            string    `json:".tag"`
 	Name           string    `json:"name"`

--- a/drivers/dropbox/util.go
+++ b/drivers/dropbox/util.go
@@ -56,11 +56,11 @@ func (d *Dropbox) request(uri, method string, callback base.ReqCallback, retry .
 		}
 		req.SetHeader("Dropbox-API-Path-Root", apiPathRootJson)
 	}
-	if method == http.MethodPost {
-		req.SetHeader("Content-Type", "application/json")
-	}
 	if callback != nil {
 		callback(req)
+	}
+	if method == http.MethodPost && req.Body!= nil {
+		req.SetHeader("Content-Type", "application/json")
 	}
 	var e ErrorResp
 	req.SetError(&e)

--- a/drivers/dropbox/util.go
+++ b/drivers/dropbox/util.go
@@ -46,6 +46,16 @@ func (d *Dropbox) refreshToken() error {
 func (d *Dropbox) request(uri, method string, callback base.ReqCallback, retry ...bool) ([]byte, error) {
 	req := base.RestyClient.R()
 	req.SetHeader("Authorization", "Bearer "+d.AccessToken)
+	if d.RootNamespaceId != "" {
+		apiPathRootJson, err := utils.Json.MarshalToString(map[string]interface{}{
+			".tag": "root",
+			"root": d.RootNamespaceId,
+		})
+		if err != nil {
+			return nil, err
+		}
+		req.SetHeader("Dropbox-API-Path-Root", apiPathRootJson)
+	}
 	if method == http.MethodPost {
 		req.SetHeader("Content-Type", "application/json")
 	}

--- a/drivers/dropbox/util.go
+++ b/drivers/dropbox/util.go
@@ -59,7 +59,7 @@ func (d *Dropbox) request(uri, method string, callback base.ReqCallback, retry .
 	if callback != nil {
 		callback(req)
 	}
-	if method == http.MethodPost && req.Body!= nil {
+	if method == http.MethodPost && req.Body != nil {
 		req.SetHeader("Content-Type", "application/json")
 	}
 	var e ErrorResp


### PR DESCRIPTION
Just started using this tool recently, it's a great project!
Still not very familiar with the codebase or golang, feel free to provide feedback and suggestions.

It's been quickly tested with my Dropbox Business account manually, now it's able to see teams folders.

## Background

Related to https://github.com/alist-org/alist/issues/5126 and https://github.com/alist-org/alist/discussions/5760

Sending Dropbox API request without a `Dropbox-API-Path-Root` header defaults to user home namespace.
To access Dropbox Team Space, proper namespace needs to be provided.

Namespace IDs can be obtained from `/2/users/get_current_account`.
For non-business users, `root_info.root_namespace_id` and `root_info.home_namespace_id` seem to be identical values.

For Business users, setting `root_namespace_id` in `Dropbox-API-Path-Root` header allows API client to start from a higher level root where the requesting user's personal home as well as other shared folders can be seen at the same time.

## Changes
- Makes a request to get namespace IDs in `Init`
- Set `Dropbox-API-Path-Root` header in `request` method when `d.RootNamespaceId` is available

## References
- https://www.dropbox.com/developers/documentation/http/documentation#users-get_current_account
- https://developers.dropbox.com/en-us/dbx-team-files-guide#interacting-with-team-content
- https://qiita.com/nkmk1215/items/95e2d97e5bb89a8b904a
- https://github.com/rclone/rclone/blob/810644e8735330db1cbd70745802284e8624b423/backend/dropbox/dropbox.go#L184
