### PR TITLE
docs: change outdated repository link to alist-org

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions & Discussions
-    url: https://github.com/Xhofe/alist/discussions
+    url: https://github.com/alist-org/alist/discussions
     about: Use GitHub discussions for message-board style questions and discussions.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
   <a href="https://goreportcard.com/report/github.com/alist-org/alist/v3">
     <img src="https://goreportcard.com/badge/github.com/alist-org/alist/v3" alt="latest version" />
   </a>
-  <a href="https://github.com/Xhofe/alist/blob/main/LICENSE">
+  <a href="https://github.com/alist-org/alist/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/Xhofe/alist" alt="License" />
   </a>
-  <a href="https://github.com/Xhofe/alist/actions?query=workflow%3ABuild">
+  <a href="https://github.com/alist-org/alist/actions?query=workflow%3ABuild">
     <img src="https://img.shields.io/github/actions/workflow/status/Xhofe/alist/build.yml?branch=main" alt="Build status" />
   </a>
-  <a href="https://github.com/Xhofe/alist/releases">
+  <a href="https://github.com/alist-org/alist/releases">
     <img src="https://img.shields.io/github/release/Xhofe/alist" alt="latest version" />
   </a>
   <a title="Crowdin" target="_blank" href="https://crwd.in/alist">
@@ -19,13 +19,13 @@
   </a>
 </div>
 <div>
-  <a href="https://github.com/Xhofe/alist/discussions">
+  <a href="https://github.com/alist-org/alist/discussions">
     <img src="https://img.shields.io/github/discussions/Xhofe/alist?color=%23ED8936" alt="discussions" />
   </a>
   <a href="https://discord.gg/F4ymsH4xv2">
     <img src="https://img.shields.io/discord/1018870125102895134?logo=discord" alt="discussions" />
   </a>
-  <a href="https://github.com/Xhofe/alist/releases">
+  <a href="https://github.com/alist-org/alist/releases">
     <img src="https://img.shields.io/github/downloads/Xhofe/alist/total?color=%239F7AEA&logo=github" alt="Downloads" />
   </a>
   <a href="https://hub.docker.com/r/xhofe/alist">
@@ -105,7 +105,7 @@ English | [中文](./README_cn.md)| [日本語](./README_ja.md) | [Contributing]
 
 ## Discussion
 
-Please go to our [discussion forum](https://github.com/Xhofe/alist/discussions) for general questions, **issues are for bug reports and feature requests only.**
+Please go to our [discussion forum](https://github.com/alist-org/alist/discussions) for general questions, **issues are for bug reports and feature requests only.**
 
 ## Sponsor
 
@@ -137,4 +137,4 @@ The `AList` is open-source software licensed under the AGPL-3.0 license.
 
 ---
 
-> [@Blog](https://nn.ci/) · [@GitHub](https://github.com/Xhofe) · [@TelegramGroup](https://t.me/alist_chat) · [@Discord](https://discord.gg/F4ymsH4xv2)
+> [@Blog](https://nn.ci/) · [@GitHub](https://github.com/alist-org) · [@TelegramGroup](https://t.me/alist_chat) · [@Discord](https://discord.gg/F4ymsH4xv2)

--- a/README_cn.md
+++ b/README_cn.md
@@ -5,13 +5,13 @@
   <a href="https://goreportcard.com/report/github.com/alist-org/alist/v3">
     <img src="https://goreportcard.com/badge/github.com/alist-org/alist/v3" alt="latest version" />
   </a>
-  <a href="https://github.com/Xhofe/alist/blob/main/LICENSE">
+  <a href="https://github.com/alist-org/alist/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/Xhofe/alist" alt="License" />
   </a>
-  <a href="https://github.com/Xhofe/alist/actions?query=workflow%3ABuild">
+  <a href="https://github.com/alist-org/alist/actions?query=workflow%3ABuild">
     <img src="https://img.shields.io/github/actions/workflow/status/Xhofe/alist/build.yml?branch=main" alt="Build status" />
   </a>
-  <a href="https://github.com/Xhofe/alist/releases">
+  <a href="https://github.com/alist-org/alist/releases">
     <img src="https://img.shields.io/github/release/Xhofe/alist" alt="latest version" />
   </a>
   <a title="Crowdin" target="_blank" href="https://crwd.in/alist">
@@ -19,13 +19,13 @@
   </a>
 </div>
 <div>
-  <a href="https://github.com/Xhofe/alist/discussions">
+  <a href="https://github.com/alist-org/alist/discussions">
     <img src="https://img.shields.io/github/discussions/Xhofe/alist?color=%23ED8936" alt="discussions" />
   </a>
   <a href="https://discord.gg/F4ymsH4xv2">
     <img src="https://img.shields.io/discord/1018870125102895134?logo=discord" alt="discussions" />
   </a>
-  <a href="https://github.com/Xhofe/alist/releases">
+  <a href="https://github.com/alist-org/alist/releases">
     <img src="https://img.shields.io/github/downloads/Xhofe/alist/total?color=%239F7AEA&logo=github" alt="Downloads" />
   </a>
   <a href="https://hub.docker.com/r/xhofe/alist">
@@ -104,7 +104,7 @@
 
 ## 讨论
 
-一般问题请到[讨论论坛](https://github.com/Xhofe/alist/discussions) ，**issue仅针对错误报告和功能请求。**
+一般问题请到[讨论论坛](https://github.com/alist-org/alist/discussions) ，**issue仅针对错误报告和功能请求。**
 
 ## 赞助
 
@@ -135,4 +135,4 @@ Thanks goes to these wonderful people:
 
 ---
 
-> [@博客](https://nn.ci/) · [@GitHub](https://github.com/Xhofe) · [@Telegram群](https://t.me/alist_chat) · [@Discord](https://discord.gg/F4ymsH4xv2)
+> [@博客](https://nn.ci/) · [@GitHub](https://github.com/alist-org) · [@Telegram群](https://t.me/alist_chat) · [@Discord](https://discord.gg/F4ymsH4xv2)

--- a/README_ja.md
+++ b/README_ja.md
@@ -5,13 +5,13 @@
   <a href="https://goreportcard.com/report/github.com/alist-org/alist/v3">
     <img src="https://goreportcard.com/badge/github.com/alist-org/alist/v3" alt="latest version" />
   </a>
-  <a href="https://github.com/Xhofe/alist/blob/main/LICENSE">
+  <a href="https://github.com/alist-org/alist/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/Xhofe/alist" alt="License" />
   </a>
-  <a href="https://github.com/Xhofe/alist/actions?query=workflow%3ABuild">
+  <a href="https://github.com/alist-org/alist/actions?query=workflow%3ABuild">
     <img src="https://img.shields.io/github/actions/workflow/status/Xhofe/alist/build.yml?branch=main" alt="Build status" />
   </a>
-  <a href="https://github.com/Xhofe/alist/releases">
+  <a href="https://github.com/alist-org/alist/releases">
     <img src="https://img.shields.io/github/release/Xhofe/alist" alt="latest version" />
   </a>
   <a title="Crowdin" target="_blank" href="https://crwd.in/alist">
@@ -19,13 +19,13 @@
   </a>
 </div>
 <div>
-  <a href="https://github.com/Xhofe/alist/discussions">
+  <a href="https://github.com/alist-org/alist/discussions">
     <img src="https://img.shields.io/github/discussions/Xhofe/alist?color=%23ED8936" alt="discussions" />
   </a>
   <a href="https://discord.gg/F4ymsH4xv2">
     <img src="https://img.shields.io/discord/1018870125102895134?logo=discord" alt="discussions" />
   </a>
-  <a href="https://github.com/Xhofe/alist/releases">
+  <a href="https://github.com/alist-org/alist/releases">
     <img src="https://img.shields.io/github/downloads/Xhofe/alist/total?color=%239F7AEA&logo=github" alt="Downloads" />
   </a>
   <a href="https://hub.docker.com/r/xhofe/alist">
@@ -105,7 +105,7 @@
 
 ## ディスカッション
 
-一般的なご質問は[ディスカッションフォーラム](https://github.com/Xhofe/alist/discussions)をご利用ください。**問題はバグレポートと機能リクエストのみです。**
+一般的なご質問は[ディスカッションフォーラム](https://github.com/alist-org/alist/discussions)をご利用ください。**問題はバグレポートと機能リクエストのみです。**
 
 ## スポンサー
 
@@ -137,4 +137,4 @@ https://alist.nn.ci/guide/sponsor.html
 
 ---
 
-> [@Blog](https://nn.ci/) · [@GitHub](https://github.com/Xhofe) · [@TelegramGroup](https://t.me/alist_chat) · [@Discord](https://discord.gg/F4ymsH4xv2)
+> [@Blog](https://nn.ci/) · [@GitHub](https://github.com/alist-org) · [@TelegramGroup](https://t.me/alist_chat) · [@Discord](https://discord.gg/F4ymsH4xv2)


### PR DESCRIPTION
我注意到您的仓库已经更改为alist-org所有，虽然GitHub提供了仓库重定向，但它毕竟与准确的仓库地址有差别。

我亦会在其他相关项目中提交PR，这是在主页下方点击“由 AList 驱动”时发现的。

相关的PR还包括：

* https://github.com/alist-org/alist-web/pull/142

此外，文档中依然有很多没有更改的链接，您觉得有必要对过往的文档进行更改吗？