### PR TITLE
Add docker image with ffmpeg release

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -55,6 +55,25 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x
 
+      - name: Docker meta with ffmpeg
+        id: meta-ffmpeg
+        uses: docker/metadata-action@v5
+        with:
+          images: xhofe/alist
+          flavor: |
+            latest=true
+            suffix=-ffmpeg,onlatest=true
+
+      - name: Build and push with ffmpeg
+        id: docker_build_ffmpeg
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.ffmpeg
+          push: true
+          tags: ${{ steps.meta-ffmpeg.outputs.tags }}
+          labels: ${{ steps.meta-ffmpeg.outputs.labels }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x
+
   build_docker_with_aria2:
     needs: build_docker
     name: Build docker with aria2

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -69,7 +69,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.ffmpeg
-          push: true
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta-ffmpeg.outputs.tags }}
           labels: ${{ steps.meta-ffmpeg.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -49,6 +49,25 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x
 
+      - name: Docker meta with ffmpeg
+        id: meta-ffmpeg
+        uses: docker/metadata-action@v5
+        with:
+          images: xhofe/alist
+          flavor: |
+            latest=true
+            suffix=-ffmpeg,onlatest=true
+            
+      - name: Build and push with ffmpeg
+        id: docker_build_ffmpeg
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.ffmpeg
+          push: true
+          tags: ${{ steps.meta-ffmpeg.outputs.tags }}
+          labels: ${{ steps.meta-ffmpeg.outputs.labels }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x
+
   release_docker_with_aria2:
     needs: release_docker
     name: Release docker with aria2

--- a/Dockerfile.ffmpeg
+++ b/Dockerfile.ffmpeg
@@ -1,0 +1,4 @@
+FROM xhofe/alist:latest
+RUN apk update && \
+    apk add --no-cache ffmpeg \
+    rm -rf /var/cache/apk/*


### PR DESCRIPTION
Add docker image release with ffmpeg installed. The new images will have the suffix `-ffmpeg` such as `latest-ffmpeg` and `v3.30.0-ffmpeg`. [Test Action](https://github.com/Mmx233/alist/actions/runs/7947695437/job/21696836480) ; [Test Images](https://hub.docker.com/repository/docker/mmx233/alist/tags)

![image](https://github.com/alist-org/alist/assets/36563672/9ec10a39-0149-451d-a66f-d9cbdac2af5f)