### PR TITLE
feat(seafile): improve features, support access to encrypted library, etc

### DIFF
--- a/drivers/seafile/meta.go
+++ b/drivers/seafile/meta.go
@@ -11,7 +11,8 @@ type Addition struct {
 	Address  string `json:"address" required:"true"`
 	UserName string `json:"username" required:"true"`
 	Password string `json:"password" required:"true"`
-	RepoId   string `json:"repoId" required:"true"`
+	RepoId   string `json:"repoId" required:"false"`
+	RepoPwd  string `json:"repoPwd" required:"false"`
 }
 
 var config = driver.Config{

--- a/drivers/seafile/types.go
+++ b/drivers/seafile/types.go
@@ -1,14 +1,44 @@
 package seafile
 
+import "time"
+
 type AuthTokenResp struct {
 	Token string `json:"token"`
 }
 
-type RepoDirItemResp struct {
+type RepoItemResp struct {
 	Id         string `json:"id"`
-	Type       string `json:"type"` // dir, file
+	Type       string `json:"type"` // repo, dir, file
 	Name       string `json:"name"`
 	Size       int64  `json:"size"`
 	Modified   int64  `json:"mtime"`
 	Permission string `json:"permission"`
+}
+
+type LibraryItemResp struct {
+	RepoItemResp
+	OwnerContactEmail    string `json:"owner_contact_email"`
+	OwnerName            string `json:"owner_name"`
+	Owner                string `json:"owner"`
+	ModifierEmail        string `json:"modifier_email"`
+	ModifierContactEmail string `json:"modifier_contact_email"`
+	ModifierName         string `json:"modifier_name"`
+	Virtual              bool   `json:"virtual"`
+	MtimeRelative        string `json:"mtime_relative"`
+	Encrypted            bool   `json:"encrypted"`
+	Version              int    `json:"version"`
+	HeadCommitId         string `json:"head_commit_id"`
+	Root                 string `json:"root"`
+	Salt                 string `json:"salt"`
+	SizeFormatted        string `json:"size_formatted"`
+}
+
+type RepoDirItemResp struct {
+	RepoItemResp
+}
+
+type LibraryInfo struct {
+	LibraryItemResp
+	decryptedTime    time.Time
+	decryptedSuccess bool
 }

--- a/drivers/seafile/util.go
+++ b/drivers/seafile/util.go
@@ -1,8 +1,13 @@
 package seafile
 
 import (
+	"errors"
 	"fmt"
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/pkg/utils"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/go-resty/resty/v2"
@@ -60,3 +65,110 @@ func (d *Seafile) request(method string, pathname string, callback base.ReqCallb
 	}
 	return res.Body(), nil
 }
+
+func (d *Seafile) getRepoAndPath(fullPath string) (repo *LibraryInfo, path string, err error) {
+	libraryMap := d.libraryMap
+	repoId := d.Addition.RepoId
+	if repoId != "" {
+		if len(repoId) == 36 /* uuid */ {
+			for _, library := range libraryMap {
+				if library.Id == repoId {
+					return library, fullPath, nil
+				}
+			}
+		}
+	} else {
+		var repoName string
+		str := fullPath[1:]
+		pos := strings.IndexRune(str, '/')
+		if pos == -1 {
+			repoName = str
+		} else {
+			repoName = str[:pos]
+		}
+		path = utils.FixAndCleanPath(fullPath[1+len(repoName):])
+		if library, ok := libraryMap[repoName]; ok {
+			return library, path, nil
+		}
+	}
+	return nil, "", errs.ObjectNotFound
+}
+
+func (d *Seafile) listLibraries() (resp []LibraryItemResp, err error) {
+	repoId := d.Addition.RepoId
+	if repoId == "" {
+		_, err = d.request(http.MethodGet, "/api2/repos/", func(req *resty.Request) {
+			req.SetResult(&resp)
+		})
+	} else {
+		var oneResp LibraryItemResp
+		_, err = d.request(http.MethodGet, fmt.Sprintf("/api2/repos/%s/", repoId), func(req *resty.Request) {
+			req.SetResult(&oneResp)
+		})
+		if err == nil {
+			resp = append(resp, oneResp)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	libraryMap := make(map[string]*LibraryInfo)
+	var putLibraryMap func(library LibraryItemResp, index int)
+	putLibraryMap = func(library LibraryItemResp, index int) {
+		name := library.Name
+		if index > 0 {
+			name = fmt.Sprintf("%s (%d)", name, index)
+		}
+		if _, exist := libraryMap[name]; exist {
+			putLibraryMap(library, index+1)
+		} else {
+			libraryInfo := LibraryInfo{}
+			data, _ := utils.Json.Marshal(library)
+			_ = utils.Json.Unmarshal(data, &libraryInfo)
+			libraryMap[name] = &libraryInfo
+		}
+	}
+	for _, library := range resp {
+		putLibraryMap(library, 0)
+	}
+	d.libraryMap = libraryMap
+	return resp, nil
+}
+
+var repoPwdNotConfigured = errors.New("library password not configured")
+var repoPwdIncorrect = errors.New("library password is incorrect")
+
+func (d *Seafile) decryptLibrary(repo *LibraryInfo) (err error) {
+	if !repo.Encrypted {
+		return nil
+	}
+	if d.RepoPwd == "" {
+		return repoPwdNotConfigured
+	}
+	now := time.Now()
+	decryptedTime := repo.decryptedTime
+	if repo.decryptedSuccess {
+		if now.Sub(decryptedTime).Minutes() <= 30 {
+			return nil
+		}
+	} else {
+		if now.Sub(decryptedTime).Seconds() <= 10 {
+			return repoPwdIncorrect
+		}
+	}
+	var resp string
+	_, err = d.request(http.MethodPost, fmt.Sprintf("/api2/repos/%s/", repo.Id), func(req *resty.Request) {
+		req.SetResult(&resp).SetFormData(map[string]string{
+			"password": d.RepoPwd,
+		})
+	})
+	repo.decryptedTime = time.Now()
+	if err != nil || !strings.Contains(resp, "success") {
+		repo.decryptedSuccess = false
+		return err
+	}
+	repo.decryptedSuccess = true
+	return nil
+}
+
+


### PR DESCRIPTION
Add multiple features:
1. Support accessing encrypted libraries in Seafile.
2. It is no longer mandatory to fill in the `RepoId`, support displaying all libraries, and keep the configuration compatible.
3. Support copying and moving between different libraries.

Changes to document: https://github.com/alist-org/docs/pull/333


添加多个功能：
 1. 支持访问 Seafile 加密库
 2. 可以不再必填资料库ID，支持展示所有资料库，配置保持兼容
 3. 支持在不同资料库间复制、移动

改动较多，不过我仔细测了各种不同配置下的各个功能，应该没什么问题。
最开始添加这个 Seafile 驱动的这位 @wangzexi 可以看一下。

文档的改动：https://github.com/alist-org/docs/pull/333