### PR TITLE
fix: 修复容器运行环境时区的问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,18 @@ RUN go mod download
 COPY ./ ./
 RUN bash build.sh release docker
 
-FROM alpine:edge
+FROM alpine:3.19
 LABEL MAINTAINER="i@nn.ci"
 VOLUME /opt/alist/data/
 WORKDIR /opt/alist/
 COPY --from=builder /app/bin/alist ./
 COPY entrypoint.sh /entrypoint.sh
-RUN apk update && \
+RUN sed -i "s/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g" /etc/apk/repositories && \
     apk upgrade --no-cache && \
-    apk add --no-cache bash ca-certificates su-exec tzdata; \
+    apk add --no-cache bash ca-certificates su-exec tzdata alpine-conf && \
+    /sbin/setup-timezone -z Asia/Shanghai && \
     chmod +x /entrypoint.sh && \
-    rm -rf /var/cache/apk/*
+    apk del alpine-conf && rm -rf /var/cache/apk/*
 ENV PUID=0 PGID=0 UMASK=022
 EXPOSE 5244 5245
 CMD [ "/entrypoint.sh" ]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,16 +1,16 @@
-FROM alpine:edge
+FROM alpine:3.19
 ARG TARGETPLATFORM
 LABEL MAINTAINER="i@nn.ci"
 VOLUME /opt/alist/data/
 WORKDIR /opt/alist/
 COPY /${TARGETPLATFORM}/alist ./
 COPY entrypoint.sh /entrypoint.sh
-RUN apk update && \
+RUN sed -i "s/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g" /etc/apk/repositories && \
     apk upgrade --no-cache && \
-    apk add --no-cache bash ca-certificates su-exec tzdata; \
+    apk add --no-cache bash ca-certificates su-exec tzdata alpine-conf && \
+    /sbin/setup-timezone -z Asia/Shanghai && \
     chmod +x /entrypoint.sh && \
-    rm -rf /var/cache/apk/* && \
-    /entrypoint.sh version
+    apk del alpine-conf && rm -rf /var/cache/apk/*
 ENV PUID=0 PGID=0 UMASK=022
 EXPOSE 5244 5245
 CMD [ "/entrypoint.sh" ]


### PR DESCRIPTION
原来的Dockerfile没有处理时区的问题，默认运行的时区为UTC时间，导致应用打印的日志时间也与当下时区不符。

做了一些调整，以规避此问题。

before:

```
$ date
Thu Apr  4 09:00:32 UTC 2024
```

after:

```
$ date
Thu Apr  4 17:01:41 CST 2024
```