### PR TITLE
fix: 修复Meilisearch相关配置无法通过环境变量配置

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -77,7 +77,7 @@ type Config struct {
 	JwtSecret             string      `json:"jwt_secret" env:"JWT_SECRET"`
 	TokenExpiresIn        int         `json:"token_expires_in" env:"TOKEN_EXPIRES_IN"`
 	Database              Database    `json:"database" envPrefix:"DB_"`
-	Meilisearch           Meilisearch `json:"meilisearch" env:"MEILISEARCH"`
+	Meilisearch           Meilisearch `json:"meilisearch" envPrefix:"MEILISEARCH_"`
 	Scheme                Scheme      `json:"scheme"`
 	TempDir               string      `json:"temp_dir" env:"TEMP_DIR"`
 	BleveDir              string      `json:"bleve_dir" env:"BLEVE_DIR"`


### PR DESCRIPTION
related: #6060 

按照作者的意图，配置的对应环境变量应当是

```
MEILISEARCH_HOST
MEILISEARCH_API_KEY
MEILISEARCH_INDEX_PREFIX
```

但是原先写法中错误将`envPrefix`写成了`env`，所以上述形式的meilisearch环境变量配置无法被解析

ref: https://github.com/caarlos0/env/blob/4f6bb22b03e366362642bc1b1b2bb8ba5b5786ef/env.go#L149-L159
