### PR TITLE
feat: Add token login for Seafile

### DIFF
--- a/drivers/seafile/meta.go
+++ b/drivers/seafile/meta.go
@@ -9,8 +9,9 @@ type Addition struct {
 	driver.RootPath
 
 	Address  string `json:"address" required:"true"`
-	UserName string `json:"username" required:"true"`
-	Password string `json:"password" required:"true"`
+	UserName string `json:"username" required:"false"`
+	Password string `json:"password" required:"false"`
+	Token    string `json:"token" required:"false"`	
 	RepoId   string `json:"repoId" required:"false"`
 	RepoPwd  string `json:"repoPwd" required:"false"`
 }

--- a/drivers/seafile/util.go
+++ b/drivers/seafile/util.go
@@ -14,6 +14,10 @@ import (
 )
 
 func (d *Seafile) getToken() error {
+	if d.Token != "" {
+		d.authorization = fmt.Sprintf("Token %s", d.Token)
+		return nil
+	}
 	var authResp AuthTokenResp
 	res, err := base.RestyClient.R().
 		SetResult(&authResp).


### PR DESCRIPTION
Fixes #5302 
Seafile 驱动本身使用 username 和 password 获取 token，这对于部分单点登录的用户来说无法使用
这一 PR 在驱动中添加了 Token 字段，对于填写了 token 的用户可以跳过获取 token 这一步
注：这是我人生第一次交 PR，有什么不对的轻喷