### PR TITLE
fix: correct the download url got by Cloudreve driver

### DIFF
--- a/drivers/cloudreve/driver.go
+++ b/drivers/cloudreve/driver.go
@@ -71,7 +71,9 @@ func (d *Cloudreve) Link(ctx context.Context, file model.Obj, args model.LinkArg
 	if err != nil {
 		return nil, err
 	}
-	dUrl = d.Address + dUrl
+	if strings.HasPrefix(dUrl, "/api") {
+		dUrl = d.Address + dUrl
+	}
 	return &model.Link{
 		URL: dUrl,
 	}, nil

--- a/drivers/cloudreve/driver.go
+++ b/drivers/cloudreve/driver.go
@@ -71,6 +71,7 @@ func (d *Cloudreve) Link(ctx context.Context, file model.Obj, args model.LinkArg
 	if err != nil {
 		return nil, err
 	}
+	dUrl = d.Address + dUrl
 	return &model.Link{
 		URL: dUrl,
 	}, nil


### PR DESCRIPTION
Fixes #6265
从 Cloudreve 的较新版本获取到的链接是不完整的，其中不包含域名。这会导致下载时访问 `{Alist网址}/api/v3/file/download/*` 而不是 `{Cloudreve网址}/api/v3/file/download/*`，这一 PR 在获取到的链接前添加了域名。