### PR TITLE
使存储初始化顺序可控，防止加密存储初始化失败

### DIFF
--- a/internal/bootstrap/storage.go
+++ b/internal/bootstrap/storage.go
@@ -21,8 +21,8 @@ func LoadStorages() {
 			if err != nil {
 				utils.Log.Errorf("failed get enabled storages: %+v", err)
 			} else {
-				utils.Log.Infof("success load storage: [%s], driver: [%s]",
-					storages[i].MountPath, storages[i].Driver)
+				utils.Log.Infof("success load storage: [%s], driver: [%s], order: [%d]",
+					storages[i].MountPath, storages[i].Driver, storages[i].Order)
 			}
 		}
 		conf.StoragesLoaded = true

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/pkg/errors"
@@ -65,5 +66,8 @@ func GetEnabledStorages() ([]model.Storage, error) {
 	if err := db.Where(fmt.Sprintf("%s = ?", columnName("disabled")), false).Find(&storages).Error; err != nil {
 		return nil, errors.WithStack(err)
 	}
+	sort.Slice(storages, func(i, j int) bool {
+		return storages[i].Order < storages[j].Order
+	})
 	return storages, nil
 }


### PR DESCRIPTION
加密存储依赖于远端存储，如果加密存储先于远端存储初始化就会导致初始化失败。如果按Storage.Order顺序初始化，可以将加密存储的order设置一个大一点的值，这样就不会失败了