### PR TITLE
fix(test): ensure setupStorages is executed once

### DIFF
--- a/internal/op/storage_test.go
+++ b/internal/op/storage_test.go
@@ -60,7 +60,6 @@ func TestGetStorageVirtualFilesByPath(t *testing.T) {
 }
 
 func TestGetBalancedStorage(t *testing.T) {
-	setupStorages(t)
 	set := mapset.NewSet[string]()
 	for i := 0; i < 5; i++ {
 		storage := op.GetBalancedStorage("/a/d/e1")


### PR DESCRIPTION
In TestGetStorageVirtualFilesByPath() and TestGetBalancedStorage(), setupStorages() was being called twice, leading to a "UNIQUE constraint failed" error.