### PR TITLE
feat(alias): support Rename and Remove

### DIFF
--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -47,6 +47,9 @@ func (d *Alias) Init(ctx context.Context) error {
 			d.oneKey = k
 		}
 		d.autoFlatten = true
+	} else {
+		d.oneKey = ""
+		d.autoFlatten = false
 	}
 	return nil
 }

--- a/drivers/alias/meta.go
+++ b/drivers/alias/meta.go
@@ -9,7 +9,8 @@ type Addition struct {
 	// Usually one of two
 	// driver.RootPath
 	// define other
-	Paths string `json:"paths" required:"true" type:"text"`
+	Paths           string `json:"paths" required:"true" type:"text"`
+	ProtectSameName bool   `json:"protect_same_name" default:"true" required:"false" help:"Protects same-name files from Delete or Rename"`
 }
 
 var config = driver.Config{
@@ -22,6 +23,10 @@ var config = driver.Config{
 
 func init() {
 	op.RegisterDriver(func() driver.Driver {
-		return &Alias{}
+		return &Alias{
+			Addition: Addition{
+				ProtectSameName: true,
+			},
+		}
 	})
 }

--- a/drivers/alias/util.go
+++ b/drivers/alias/util.go
@@ -6,6 +6,7 @@ import (
 	stdpath "path"
 	"strings"
 
+	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/fs"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/sign"
@@ -111,4 +112,36 @@ func (d *Alias) link(ctx context.Context, dst, sub string, args model.LinkArgs) 
 	}
 	link, _, err := fs.Link(ctx, reqPath, args)
 	return link, err
+}
+
+func (d *Alias) getReqPath(ctx context.Context, obj model.Obj) (*string, error) {
+	root, sub := d.getRootAndPath(obj.GetPath())
+	if sub == "" || sub == "/" {
+		return nil, errs.NotSupport
+	}
+	dsts, ok := d.pathMap[root]
+	if !ok {
+		return nil, errs.ObjectNotFound
+	}
+	var reqPath string
+	var err error
+	for _, dst := range dsts {
+		reqPath = stdpath.Join(dst, sub)
+		_, err = fs.Get(ctx, reqPath, &fs.GetArgs{NoLog: true})
+		if err == nil {
+			if d.ProtectSameName {
+				if ok {
+					ok = false
+				} else {
+					return nil, errs.NotImplement
+				}
+			} else {
+				break
+			}
+		}
+	}
+	if err != nil {
+		return nil, errs.ObjectNotFound
+	}
+	return &reqPath, nil
 }

--- a/internal/errs/errors.go
+++ b/internal/errs/errors.go
@@ -3,6 +3,7 @@ package errs
 import (
 	"errors"
 	"fmt"
+
 	pkgerr "github.com/pkg/errors"
 )
 
@@ -32,4 +33,7 @@ func IsNotFoundError(err error) bool {
 
 func IsNotSupportError(err error) bool {
 	return errors.Is(pkgerr.Cause(err), NotSupport)
+}
+func IsNotImplement(err error) bool {
+	return errors.Is(pkgerr.Cause(err), NotImplement)
 }


### PR DESCRIPTION
此PR对 alias别名 驱动进行修改
* 支持 `重命名` 和 `删除` 操作，遇到同名时 优先级的处理跟 `下载` 一致
* 修复在 #6474 中提到的问题