### PR TITLE
feat: add `proxy_range` option for `139Yun` `Alias` `AList V3`

### DIFF
--- a/drivers/139/meta.go
+++ b/drivers/139/meta.go
@@ -14,12 +14,15 @@ type Addition struct {
 }
 
 var config = driver.Config{
-	Name:      "139Yun",
-	LocalSort: true,
+	Name:             "139Yun",
+	LocalSort:        true,
+	ProxyRangeOption: true,
 }
 
 func init() {
 	op.RegisterDriver(func() driver.Driver {
-		return &Yun139{}
+		d := &Yun139{}
+		d.ProxyRange = true
+		return d
 	})
 }

--- a/drivers/alias/meta.go
+++ b/drivers/alias/meta.go
@@ -14,11 +14,12 @@ type Addition struct {
 }
 
 var config = driver.Config{
-	Name:        "Alias",
-	LocalSort:   true,
-	NoCache:     true,
-	NoUpload:    true,
-	DefaultRoot: "/",
+	Name:             "Alias",
+	LocalSort:        true,
+	NoCache:          true,
+	NoUpload:         true,
+	DefaultRoot:      "/",
+	ProxyRangeOption: true,
 }
 
 func init() {

--- a/drivers/alias/util.go
+++ b/drivers/alias/util.go
@@ -103,12 +103,16 @@ func (d *Alias) link(ctx context.Context, dst, sub string, args model.LinkArgs) 
 		return nil, err
 	}
 	if common.ShouldProxy(storage, stdpath.Base(sub)) {
-		return &model.Link{
+		link := &model.Link{
 			URL: fmt.Sprintf("%s/p%s?sign=%s",
 				common.GetApiUrl(args.HttpReq),
 				utils.EncodePath(reqPath, true),
 				sign.Sign(reqPath)),
-		}, nil
+		}
+		if args.HttpReq != nil && d.ProxyRange {
+			link.RangeReadCloser = common.NoProxyRange
+		}
+		return link, nil
 	}
 	link, _, err := fs.Link(ctx, reqPath, args)
 	return link, err

--- a/drivers/alist_v3/meta.go
+++ b/drivers/alist_v3/meta.go
@@ -16,10 +16,11 @@ type Addition struct {
 }
 
 var config = driver.Config{
-	Name:        "AList V3",
-	LocalSort:   true,
-	DefaultRoot: "/",
-	CheckStatus: true,
+	Name:             "AList V3",
+	LocalSort:        true,
+	DefaultRoot:      "/",
+	CheckStatus:      true,
+	ProxyRangeOption: true,
 }
 
 func init() {

--- a/internal/driver/config.go
+++ b/internal/driver/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	CheckStatus       bool   `json:"-"`
 	Alert             string `json:"alert"` //info,success,warning,danger
 	NoOverwriteUpload bool   `json:"-"`     // whether to support overwrite upload
+	ProxyRangeOption  bool   `json:"-"`
 }
 
 func (c Config) MustProxy() bool {

--- a/internal/model/storage.go
+++ b/internal/model/storage.go
@@ -27,6 +27,7 @@ type Sort struct {
 type Proxy struct {
 	WebProxy     bool   `json:"web_proxy"`
 	WebdavPolicy string `json:"webdav_policy"`
+	ProxyRange   bool   `json:"proxy_range"`
 	DownProxyUrl string `json:"down_proxy_url"`
 }
 

--- a/internal/op/driver.go
+++ b/internal/op/driver.go
@@ -93,6 +93,17 @@ func getMainItems(config driver.Config) []driver.Item {
 			Required: true,
 		},
 		}...)
+		if config.ProxyRangeOption {
+			item := driver.Item{
+				Name: "proxy_range",
+				Type: conf.TypeBool,
+				Help: "Need to enable proxy",
+			}
+			if config.Name == "139Yun" {
+				item.Default = "true"
+			}
+			items = append(items, item)
+		}
 	} else {
 		items = append(items, driver.Item{
 			Name:     "webdav_policy",

--- a/server/common/proxy.go
+++ b/server/common/proxy.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/net"
+	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/pkg/http_range"
 	"github.com/alist-org/alist/v3/pkg/utils"
+	log "github.com/sirupsen/logrus"
 )
 
 func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.Obj) error {
@@ -81,4 +83,22 @@ func attachFileName(w http.ResponseWriter, file model.Obj) {
 	fileName := file.GetName()
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`, fileName, url.PathEscape(fileName)))
 	w.Header().Set("Content-Type", utils.GetMimeType(fileName))
+}
+
+var NoProxyRange = &model.RangeReadCloser{}
+
+func ProxyRange(link *model.Link, size int64) {
+	if link.MFile != nil {
+		return
+	}
+	if link.RangeReadCloser == nil {
+		var rrc, err = stream.GetRangeReadCloserFromLink(size, link)
+		if err != nil {
+			log.Warnf("ProxyRange error: %s", err)
+			return
+		}
+		link.RangeReadCloser = rrc
+	} else if link.RangeReadCloser == NoProxyRange {
+		link.RangeReadCloser = nil
+	}
 }

--- a/server/handles/down.go
+++ b/server/handles/down.go
@@ -106,6 +106,9 @@ func Proxy(c *gin.Context) {
 				return
 			}
 		}
+		if storage.GetStorage().ProxyRange {
+			common.ProxyRange(link, file.GetSize())
+		}
 		err = common.Proxy(c.Writer, c.Request, link, file)
 		if err != nil {
 			common.ErrorResp(c, err, 500, true)

--- a/server/webdav/webdav.go
+++ b/server/webdav/webdav.go
@@ -247,6 +247,9 @@ func (h *Handler) handleGetHeadPost(w http.ResponseWriter, r *http.Request) (sta
 		if err != nil {
 			return http.StatusInternalServerError, err
 		}
+		if storage.GetStorage().ProxyRange {
+			common.ProxyRange(link, fi.GetSize())
+		}
 		err = common.Proxy(w, r, link, fi)
 		if err != nil {
 			log.Errorf("webdav proxy error: %+v", err)


### PR DESCRIPTION
此PR增加一个`proxy_range`选项，需要先启用 web代理 或者 webdav本地代理 才会生效
* `139Yun` 驱动开启这个选项后，可解决即使开启代理但下载链接没有返回正确的http状态码导致的一些问题，例如视频无法播放、不支持断点续传等
*  `Alias` 驱动添加是为了满足某些场景，例如 `139Yun` 走302， 然后通过 开启代理的 `Alias` 后，下载用 `139Yun` 走302，播放视频用 开启代理的 `Alias`，减少不必要的负载
*  `AList V3` 驱动添加是为了 服务器的alist挂载 `139Yun` 走302，然后本地的alist通过 开启代理的 `AList V3` 挂载 服务器的alist 播放视频等，达到不消化服务器流量的目的，移动卡还能免流