### PR TITLE
FTP 自定义编码支持 / Add FTP Encoding Support

### DIFF
--- a/drivers/ftp/meta.go
+++ b/drivers/ftp/meta.go
@@ -3,10 +3,28 @@ package ftp
 import (
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/op"
+	"github.com/axgle/mahonia"
 )
+
+func encode(str string, encoding string) string {
+	if encoding == "" {
+		return str
+	}
+	encoder := mahonia.NewEncoder(encoding)
+	return encoder.ConvertString(str)
+}
+
+func decode(str string, encoding string) string {
+	if encoding == "" {
+		return str
+	}
+	decoder := mahonia.NewDecoder(encoding)
+	return decoder.ConvertString(str)
+}
 
 type Addition struct {
 	Address  string `json:"address" required:"true"`
+	Encoding string `json:"encoding" required:"true"`
 	Username string `json:"username" required:"true"`
 	Password string `json:"password" required:"true"`
 	driver.RootPath

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/aead/ecdh v0.2.0 // indirect
 	github.com/andreburgaud/crypt2go v1.2.0 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
+	github.com/axgle/mahonia v0.0.0-20180208002826-3358181d7394
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevB
 github.com/aws/aws-sdk-go v1.38.20/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.50.24 h1:3o2Pg7mOoVL0jv54vWtuafoZqAeEXLhm1tltWA2GcEw=
 github.com/aws/aws-sdk-go v1.50.24/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/axgle/mahonia v0.0.0-20180208002826-3358181d7394 h1:OYA+5W64v3OgClL+IrOD63t4i/RW7RqrAVl9LTZ9UqQ=
+github.com/axgle/mahonia v0.0.0-20180208002826-3358181d7394/go.mod h1:Q8n74mJTIgjX4RBBcHnJ05h//6/k6foqmgE45jTQtxg=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=


### PR DESCRIPTION
使用 `"github.com/axgle/mahonia"` 库进行了编码转换，使得连接不支持 UTF-8 的 FTP 服务器时，可以自选编码（如 gbk）。

<img width="121" alt="截屏2024-05-27 16 09 57" src="https://github.com/alist-org/alist/assets/85665268/8af13a24-9993-4880-9d6c-590464da5160">

fixed #1260 
