### PR TITLE
修复：数据库不是sqlite3时会乱序的bug

### DIFF
--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -34,6 +34,7 @@ func initSettings() {
 	// create or save setting
 	for i := range initialSettingItems {
 		item := &initialSettingItems[i]
+		item.Index = uint(i)
 		if item.PreDefault == "" {
 			item.PreDefault = item.Value
 		}

--- a/internal/db/meta.go
+++ b/internal/db/meta.go
@@ -34,7 +34,7 @@ func GetMetas(pageIndex, pageSize int) (metas []model.Meta, count int64, err err
 	if err = metaDB.Count(&count).Error; err != nil {
 		return nil, 0, errors.Wrapf(err, "failed get metas count")
 	}
-	if err = metaDB.Offset((pageIndex - 1) * pageSize).Limit(pageSize).Find(&metas).Error; err != nil {
+	if err = metaDB.Order(columnName("id")).Offset((pageIndex - 1) * pageSize).Limit(pageSize).Find(&metas).Error; err != nil {
 		return nil, 0, errors.Wrapf(err, "failed get find metas")
 	}
 	return metas, count, nil

--- a/internal/db/settingitem.go
+++ b/internal/db/settingitem.go
@@ -49,7 +49,8 @@ func GetSettingItemsByGroup(group int) ([]model.SettingItem, error) {
 
 func GetSettingItemsInGroups(groups []int) ([]model.SettingItem, error) {
 	var settingItems []model.SettingItem
-	if err := db.Where(fmt.Sprintf("%s in ?", columnName("group")), groups).Find(&settingItems).Error; err != nil {
+	err := db.Order(columnName("index")).Where(fmt.Sprintf("%s in ?", columnName("group")), groups).Find(&settingItems).Error
+	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	return settingItems, nil

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/pkg/errors"
@@ -36,7 +35,7 @@ func GetStorages(pageIndex, pageSize int) ([]model.Storage, int64, error) {
 		return nil, 0, errors.Wrapf(err, "failed get storages count")
 	}
 	var storages []model.Storage
-	if err := storageDB.Order(columnName("order")).Offset((pageIndex - 1) * pageSize).Limit(pageSize).Find(&storages).Error; err != nil {
+	if err := addStorageOrder(storageDB).Order(columnName("order")).Offset((pageIndex - 1) * pageSize).Limit(pageSize).Find(&storages).Error; err != nil {
 		return nil, 0, errors.WithStack(err)
 	}
 	return storages, count, nil
@@ -63,11 +62,9 @@ func GetStorageByMountPath(mountPath string) (*model.Storage, error) {
 
 func GetEnabledStorages() ([]model.Storage, error) {
 	var storages []model.Storage
-	if err := db.Where(fmt.Sprintf("%s = ?", columnName("disabled")), false).Find(&storages).Error; err != nil {
+	err := addStorageOrder(db).Where(fmt.Sprintf("%s = ?", columnName("disabled")), false).Find(&storages).Error
+	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	sort.Slice(storages, func(i, j int) bool {
-		return storages[i].Order < storages[j].Order
-	})
 	return storages, nil
 }

--- a/internal/db/user.go
+++ b/internal/db/user.go
@@ -54,7 +54,7 @@ func GetUsers(pageIndex, pageSize int) (users []model.User, count int64, err err
 	if err := userDB.Count(&count).Error; err != nil {
 		return nil, 0, errors.Wrapf(err, "failed get users count")
 	}
-	if err := userDB.Offset((pageIndex - 1) * pageSize).Limit(pageSize).Find(&users).Error; err != nil {
+	if err := userDB.Order(columnName("id")).Offset((pageIndex - 1) * pageSize).Limit(pageSize).Find(&users).Error; err != nil {
 		return nil, 0, errors.Wrapf(err, "failed get find users")
 	}
 	return users, count, nil

--- a/internal/db/util.go
+++ b/internal/db/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/alist-org/alist/v3/internal/conf"
+	"gorm.io/gorm"
 )
 
 func columnName(name string) string {
@@ -11,4 +12,8 @@ func columnName(name string) string {
 		return fmt.Sprintf(`"%s"`, name)
 	}
 	return fmt.Sprintf("`%s`", name)
+}
+
+func addStorageOrder(db *gorm.DB) *gorm.DB {
+	return db.Order(fmt.Sprintf("%s, %s", columnName("order"), columnName("id")))
 }

--- a/internal/model/setting.go
+++ b/internal/model/setting.go
@@ -29,6 +29,7 @@ type SettingItem struct {
 	Options    string `json:"options"`                                  // values for select
 	Group      int    `json:"group"`                                    // use to group setting in frontend
 	Flag       int    `json:"flag"`                                     // 0 = public, 1 = private, 2 = readonly, 3 = deprecated, etc.
+	Index      uint   `json:"index"`
 }
 
 func (s SettingItem) IsDeprecated() bool {


### PR DESCRIPTION
此PR解决以下问题
* 数据库为`mysql`时，修改数据时会按照 表的第一列 排序，导致 `alist-web` 设置页乱序
* 数据库为`postgres`时，修改数据时会追加到最后一行，导致 `alist-web` 存储 、用户、元信息页乱序