### PR TITLE
阿里云盘下载优先使用cdn直链

### DIFF
--- a/drivers/aliyundrive/driver.go
+++ b/drivers/aliyundrive/driver.go
@@ -109,6 +109,9 @@ func (d *AliDrive) Link(ctx context.Context, file model.Obj, args model.LinkArgs
 	res, err, _ := d.request("https://bj29.api.aliyunpds.com/v2/file/get_download_url", http.MethodPost, func(req *resty.Request) {
 		req.SetBody(data)
 	}, nil)
+	if err != nil {
+		return nil, err
+	}
 	// 尝试获取 cdn_url
 	cdnURL := utils.Json.Get(res, "cdn_url").ToString()
 	var downloadURL string
@@ -117,9 +120,6 @@ func (d *AliDrive) Link(ctx context.Context, file model.Obj, args model.LinkArgs
 	} else {
 		// 如果 cdn_url 为空，则获取 url
 		downloadURL = utils.Json.Get(res, "url").ToString()
-	}
-	if err != nil {
-		return nil, err
 	}
 	return &model.Link{
 		Header: http.Header{

--- a/drivers/aliyundrive/driver.go
+++ b/drivers/aliyundrive/driver.go
@@ -106,9 +106,18 @@ func (d *AliDrive) Link(ctx context.Context, file model.Obj, args model.LinkArgs
 		"file_id":    file.GetID(),
 		"expire_sec": 14400,
 	}
-	res, err, _ := d.request("https://api.alipan.com/v2/file/get_download_url", http.MethodPost, func(req *resty.Request) {
+	res, err, _ := d.request("https://bj29.api.aliyunpds.com/v2/file/get_download_url", http.MethodPost, func(req *resty.Request) {
 		req.SetBody(data)
 	}, nil)
+	// 尝试获取 cdn_url
+	cdnURL := utils.Json.Get(res, "cdn_url").ToString()
+	var downloadURL string
+	if cdnURL != nil && cdnURL != "" {
+		downloadURL = cdnURL
+	} else {
+		// 如果 cdn_url 为空，则获取 url
+		downloadURL = utils.Json.Get(res, "url").ToString()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +125,7 @@ func (d *AliDrive) Link(ctx context.Context, file model.Obj, args model.LinkArgs
 		Header: http.Header{
 			"Referer": []string{"https://www.alipan.com/"},
 		},
-		URL: utils.Json.Get(res, "url").ToString(),
+		URL: downloadURL,
 	}, nil
 }
 


### PR DESCRIPTION
新增功能：

- 优先提取cdn直链，可提速下载阿里云盘文件

关联issue：#6644 