### PR TITLE
feat: add pikpak offline download function

### DIFF
--- a/drivers/pikpak/driver.go
+++ b/drivers/pikpak/driver.go
@@ -218,12 +218,8 @@ func (d *PikPak) OfflineDownload(ctx context.Context, fileUrl string, parentDir 
 		"url": base.Json{
 			"url": fileUrl,
 		},
-		"parent_id": parentDir.GetID(),
-	}
-	if parentDir.GetID() == "" {
-		requestBody["folder_type"] = "DOWNLOAD"
-	} else {
-		requestBody["folder_type"] = ""
+		"parent_id":   parentDir.GetID(),
+		"folder_type": "",
 	}
 
 	var resp OfflineDownloadResp

--- a/drivers/pikpak/driver.go
+++ b/drivers/pikpak/driver.go
@@ -221,9 +221,9 @@ func (d *PikPak) OfflineDownload(ctx context.Context, fileUrl string, parentDir 
 		"parent_id": parentDir.GetID(),
 	}
 	if parentDir.GetID() == "" {
-		requestBody["folder_type"] = ""
-	} else {
 		requestBody["folder_type"] = "DOWNLOAD"
+	} else {
+		requestBody["folder_type"] = ""
 	}
 
 	var resp OfflineDownloadResp

--- a/drivers/pikpak/types.go
+++ b/drivers/pikpak/types.go
@@ -99,3 +99,72 @@ type UploadTaskData struct {
 
 	File File `json:"file"`
 }
+
+// 添加离线下载响应
+type OfflineDownloadResp struct {
+	File       *string     `json:"file"`
+	Task       OfflineTask `json:"task"`
+	UploadType string      `json:"upload_type"`
+	URL        struct {
+		Kind string `json:"kind"`
+	} `json:"url"`
+}
+
+// 离线下载列表
+type OfflineListResp struct {
+	ExpiresIn     int64         `json:"expires_in"`
+	NextPageToken string        `json:"next_page_token"`
+	Tasks         []OfflineTask `json:"tasks"`
+}
+
+// offlineTask
+type OfflineTask struct {
+	Callback          string            `json:"callback"`
+	CreatedTime       string            `json:"created_time"`
+	FileID            string            `json:"file_id"`
+	FileName          string            `json:"file_name"`
+	FileSize          string            `json:"file_size"`
+	IconLink          string            `json:"icon_link"`
+	ID                string            `json:"id"`
+	Kind              string            `json:"kind"`
+	Message           string            `json:"message"`
+	Name              string            `json:"name"`
+	Params            Params            `json:"params"`
+	Phase             string            `json:"phase"` // PHASE_TYPE_RUNNING, PHASE_TYPE_ERROR, PHASE_TYPE_COMPLETE, PHASE_TYPE_PENDING
+	Progress          int64             `json:"progress"`
+	ReferenceResource ReferenceResource `json:"reference_resource"`
+	Space             string            `json:"space"`
+	StatusSize        int64             `json:"status_size"`
+	Statuses          []string          `json:"statuses"`
+	ThirdTaskID       string            `json:"third_task_id"`
+	Type              string            `json:"type"`
+	UpdatedTime       string            `json:"updated_time"`
+	UserID            string            `json:"user_id"`
+}
+
+type Params struct {
+	Age         string  `json:"age"`
+	MIMEType    *string `json:"mime_type,omitempty"`
+	PredictType string  `json:"predict_type"`
+	URL         string  `json:"url"`
+}
+
+type ReferenceResource struct {
+	Type          string                 `json:"@type"`
+	Audit         interface{}            `json:"audit"`
+	Hash          string                 `json:"hash"`
+	IconLink      string                 `json:"icon_link"`
+	ID            string                 `json:"id"`
+	Kind          string                 `json:"kind"`
+	Medias        []Media                `json:"medias"`
+	MIMEType      string                 `json:"mime_type"`
+	Name          string                 `json:"name"`
+	Params        map[string]interface{} `json:"params"`
+	ParentID      string                 `json:"parent_id"`
+	Phase         string                 `json:"phase"`
+	Size          string                 `json:"size"`
+	Space         string                 `json:"space"`
+	Starred       bool                   `json:"starred"`
+	Tags          []string               `json:"tags"`
+	ThumbnailLink string                 `json:"thumbnail_link"`
+}

--- a/internal/offline_download/all.go
+++ b/internal/offline_download/all.go
@@ -3,5 +3,6 @@ package offline_download
 import (
 	_ "github.com/alist-org/alist/v3/internal/offline_download/aria2"
 	_ "github.com/alist-org/alist/v3/internal/offline_download/http"
+	_ "github.com/alist-org/alist/v3/internal/offline_download/pikpak"
 	_ "github.com/alist-org/alist/v3/internal/offline_download/qbit"
 )

--- a/internal/offline_download/pikpak/pikpak.go
+++ b/internal/offline_download/pikpak/pikpak.go
@@ -97,8 +97,8 @@ func (p *PikPak) Status(task *tool.DownloadTask) (*tool.Status, error) {
 		Progress:  0,
 		NewGID:    "",
 		Completed: false,
-		Status:    "",
-		Err:       nil,
+		Status:    "the task has been deleted",
+		Err:       fmt.Errorf("the task has been deleted"),
 	}
 	for _, t := range tasks {
 		if t.ID == task.GID {
@@ -108,9 +108,7 @@ func (p *PikPak) Status(task *tool.DownloadTask) (*tool.Status, error) {
 			if t.Phase == "PHASE_TYPE_ERROR" {
 				s.Err = fmt.Errorf(t.Message)
 			}
-		} else {
-			s.Status = "the task has been deleted"
-			s.Err = fmt.Errorf("the task has been deleted")
+			return s, nil
 		}
 	}
 	return s, nil

--- a/internal/offline_download/pikpak/pikpak.go
+++ b/internal/offline_download/pikpak/pikpak.go
@@ -50,7 +50,7 @@ func (p *PikPak) AddURL(args *tool.AddUrlArgs) (string, error) {
 	}
 
 	ctx := context.Background()
-	parentDir, err := op.Get(ctx, storage, actualPath)
+	parentDir, err := op.GetUnwrap(ctx, storage, actualPath)
 	if err != nil {
 		return "", err
 	}
@@ -98,7 +98,7 @@ func (p *PikPak) Status(task *tool.DownloadTask) (*tool.Status, error) {
 		NewGID:    "",
 		Completed: false,
 		Status:    "the task has been deleted",
-		Err:       fmt.Errorf("the task has been deleted"),
+		Err:       nil,
 	}
 	for _, t := range tasks {
 		if t.ID == task.GID {
@@ -111,6 +111,7 @@ func (p *PikPak) Status(task *tool.DownloadTask) (*tool.Status, error) {
 			return s, nil
 		}
 	}
+	s.Err = fmt.Errorf("the task has been deleted")
 	return s, nil
 }
 

--- a/internal/offline_download/pikpak/pikpak.go
+++ b/internal/offline_download/pikpak/pikpak.go
@@ -1,0 +1,83 @@
+package pikpak
+
+import (
+	"fmt"
+	// "github.com/alist-org/alist/v3/internal/model"
+	"context"
+
+	"github.com/alist-org/alist/v3/drivers/pikpak"
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/offline_download/tool"
+	"github.com/alist-org/alist/v3/internal/op"
+	// "github.com/alist-org/alist/v3/pkg/utils"
+	// "net/http"
+	// "net/url"
+	// "os"
+	// "path"
+	// "path/filepath"
+)
+
+type PikPak struct {
+}
+
+func (p PikPak) Name() string {
+	return "pikpak"
+}
+
+func (p PikPak) Items() []model.SettingItem {
+	return nil
+}
+
+func (p PikPak) Run(task *tool.DownloadTask) error {
+	return errs.NotSupport
+}
+
+func (p PikPak) Init() (string, error) {
+	return "ok", nil
+}
+
+func (p PikPak) IsReady() bool {
+	return true
+}
+
+func (p PikPak) AddURL(args *tool.AddUrlArgs) (string, error) {
+	// args.TempDir 已经被修改为了 DstDirPath
+	storage, actualPath, err := op.GetStorageAndActualPath(args.TempDir)
+	if err != nil {
+		return "", err
+	}
+	pikpakDriver, ok := storage.(*pikpak.PikPak)
+	if !ok {
+		return "", fmt.Errorf("unsupported storage driver for offline download, only Pikpak is supported")
+	}
+
+	ctx := context.Background()
+	parentDir, err := op.Get(ctx, storage, actualPath)
+	if err != nil {
+		return "", err
+	}
+
+	t, err := pikpakDriver.OfflineDownload(ctx, args.Url, parentDir, "")
+	if err != nil {
+		return "", fmt.Errorf("failed to add offline download task: %w", err)
+	}
+
+	return t.ID, nil
+}
+
+func (p PikPak) Remove(task *tool.DownloadTask) error {
+	panic("should not be called")
+}
+
+func (p PikPak) Status(task *tool.DownloadTask) (*tool.Status, error) {
+	s := &tool.Status{}
+	s.Completed = true
+	s.Progress = 100
+	s.Err = nil
+	return s, nil
+}
+
+func init() {
+	tool.Tools.Add(&PikPak{})
+}

--- a/internal/offline_download/pikpak/pikpak.go
+++ b/internal/offline_download/pikpak/pikpak.go
@@ -105,9 +105,7 @@ func (p PikPak) Status(task *tool.DownloadTask) (*tool.Status, error) {
 				s.Err = fmt.Errorf(t.Message)
 			}
 		} else {
-			s.Progress = 0
 			s.Status = "the task has been deleted"
-			s.Completed = false
 			s.Err = fmt.Errorf("the task has been deleted")
 		}
 	}

--- a/internal/offline_download/pikpak/pikpak.go
+++ b/internal/offline_download/pikpak/pikpak.go
@@ -12,29 +12,33 @@ import (
 )
 
 type PikPak struct {
+	refreshTaskCache bool
 }
 
-func (p PikPak) Name() string {
+func (p *PikPak) Name() string {
 	return "pikpak"
 }
 
-func (p PikPak) Items() []model.SettingItem {
+func (p *PikPak) Items() []model.SettingItem {
 	return nil
 }
 
-func (p PikPak) Run(task *tool.DownloadTask) error {
+func (p *PikPak) Run(task *tool.DownloadTask) error {
 	return errs.NotSupport
 }
 
-func (p PikPak) Init() (string, error) {
+func (p *PikPak) Init() (string, error) {
+	p.refreshTaskCache = false
 	return "ok", nil
 }
 
-func (p PikPak) IsReady() bool {
+func (p *PikPak) IsReady() bool {
 	return true
 }
 
-func (p PikPak) AddURL(args *tool.AddUrlArgs) (string, error) {
+func (p *PikPak) AddURL(args *tool.AddUrlArgs) (string, error) {
+	// 添加新任务刷新缓存
+	p.refreshTaskCache = true
 	// args.TempDir 已经被修改为了 DstDirPath
 	storage, actualPath, err := op.GetStorageAndActualPath(args.TempDir)
 	if err != nil {
@@ -59,7 +63,7 @@ func (p PikPak) AddURL(args *tool.AddUrlArgs) (string, error) {
 	return t.ID, nil
 }
 
-func (p PikPak) Remove(task *tool.DownloadTask) error {
+func (p *PikPak) Remove(task *tool.DownloadTask) error {
 	storage, _, err := op.GetStorageAndActualPath(task.DstDirPath)
 	if err != nil {
 		return err
@@ -76,7 +80,7 @@ func (p PikPak) Remove(task *tool.DownloadTask) error {
 	return nil
 }
 
-func (p PikPak) Status(task *tool.DownloadTask) (*tool.Status, error) {
+func (p *PikPak) Status(task *tool.DownloadTask) (*tool.Status, error) {
 	storage, _, err := op.GetStorageAndActualPath(task.DstDirPath)
 	if err != nil {
 		return nil, err
@@ -85,7 +89,7 @@ func (p PikPak) Status(task *tool.DownloadTask) (*tool.Status, error) {
 	if !ok {
 		return nil, fmt.Errorf("unsupported storage driver for offline download, only Pikpak is supported")
 	}
-	tasks, err := GetTasks(pikpakDriver)
+	tasks, err := p.GetTasks(pikpakDriver)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/offline_download/pikpak/util.go
+++ b/internal/offline_download/pikpak/util.go
@@ -1,0 +1,32 @@
+package pikpak
+
+import (
+	// "github.com/Xhofe/go-cache"
+
+	"context"
+
+	"github.com/alist-org/alist/v3/drivers/pikpak"
+	"github.com/alist-org/alist/v3/internal/op"
+
+	"github.com/alist-org/alist/v3/pkg/singleflight"
+)
+
+// var taskCache = cache.NewMemCache(cache.WithShards[[]pikpak.OfflineTask](16))
+var taskG singleflight.Group[[]pikpak.OfflineTask]
+
+func GetTasks(pikpakDriver *pikpak.PikPak) ([]pikpak.OfflineTask, error) {
+	key := op.Key(pikpakDriver, "/drive/v1/task")
+	tasks, err, _ := taskG.Do(key, func() ([]pikpak.OfflineTask, error) {
+		ctx := context.Background()
+		phase := []string{"PHASE_TYPE_RUNNING", "PHASE_TYPE_ERROR", "PHASE_TYPE_PENDING", "PHASE_TYPE_COMPLETE"}
+		tasks, err := pikpakDriver.OfflineList(ctx, "", phase)
+		if err != nil {
+			return nil, err
+		}
+		return tasks, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}

--- a/internal/offline_download/pikpak/util.go
+++ b/internal/offline_download/pikpak/util.go
@@ -28,9 +28,9 @@ func (p *PikPak) GetTasks(pikpakDriver *pikpak.PikPak) ([]pikpak.OfflineTask, er
 		if err != nil {
 			return nil, err
 		}
-		// 添加缓存 15s
+		// 添加缓存 10s
 		if len(tasks) > 0 {
-			taskCache.Set(key, tasks, cache.WithEx[[]pikpak.OfflineTask](time.Second*15))
+			taskCache.Set(key, tasks, cache.WithEx[[]pikpak.OfflineTask](time.Second*10))
 		} else {
 			taskCache.Del(key)
 		}

--- a/internal/offline_download/pikpak/util.go
+++ b/internal/offline_download/pikpak/util.go
@@ -1,27 +1,38 @@
 package pikpak
 
 import (
-	// "github.com/Xhofe/go-cache"
-
 	"context"
+	"time"
 
+	"github.com/Xhofe/go-cache"
 	"github.com/alist-org/alist/v3/drivers/pikpak"
 	"github.com/alist-org/alist/v3/internal/op"
-
 	"github.com/alist-org/alist/v3/pkg/singleflight"
 )
 
-// var taskCache = cache.NewMemCache(cache.WithShards[[]pikpak.OfflineTask](16))
+var taskCache = cache.NewMemCache(cache.WithShards[[]pikpak.OfflineTask](16))
 var taskG singleflight.Group[[]pikpak.OfflineTask]
 
-func GetTasks(pikpakDriver *pikpak.PikPak) ([]pikpak.OfflineTask, error) {
+func (p *PikPak) GetTasks(pikpakDriver *pikpak.PikPak) ([]pikpak.OfflineTask, error) {
 	key := op.Key(pikpakDriver, "/drive/v1/task")
+	if !p.refreshTaskCache {
+		if tasks, ok := taskCache.Get(key); ok {
+			return tasks, nil
+		}
+	}
+	p.refreshTaskCache = false
 	tasks, err, _ := taskG.Do(key, func() ([]pikpak.OfflineTask, error) {
 		ctx := context.Background()
 		phase := []string{"PHASE_TYPE_RUNNING", "PHASE_TYPE_ERROR", "PHASE_TYPE_PENDING", "PHASE_TYPE_COMPLETE"}
 		tasks, err := pikpakDriver.OfflineList(ctx, "", phase)
 		if err != nil {
 			return nil, err
+		}
+		// 添加缓存 15s
+		if len(tasks) > 0 {
+			taskCache.Set(key, tasks, cache.WithEx[[]pikpak.OfflineTask](time.Second*15))
+		} else {
+			taskCache.Del(key)
 		}
 		return tasks, nil
 	})

--- a/internal/offline_download/tool/add.go
+++ b/internal/offline_download/tool/add.go
@@ -64,11 +64,17 @@ func AddURL(ctx context.Context, args *AddURLArgs) (tache.TaskWithInfo, error) {
 
 	uid := uuid.NewString()
 	tempDir := filepath.Join(conf.Conf.TempDir, args.Tool, uid)
+	DeletePolicy := args.DeletePolicy
+	if args.Tool == "pikpak" {
+		tempDir = args.DstDirPath
+		// 防止将下载好的
+		DeletePolicy = DeleteNever
+	}
 	t := &DownloadTask{
 		Url:          args.URL,
 		DstDirPath:   args.DstDirPath,
 		TempDir:      tempDir,
-		DeletePolicy: args.DeletePolicy,
+		DeletePolicy: DeletePolicy,
 		tool:         tool,
 	}
 	DownloadTaskManager.Add(t)

--- a/internal/offline_download/tool/add.go
+++ b/internal/offline_download/tool/add.go
@@ -2,13 +2,14 @@ package tool
 
 import (
 	"context"
+	"path/filepath"
+
 	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/xhofe/tache"
-	"path/filepath"
 )
 
 type DeletePolicy string
@@ -64,17 +65,17 @@ func AddURL(ctx context.Context, args *AddURLArgs) (tache.TaskWithInfo, error) {
 
 	uid := uuid.NewString()
 	tempDir := filepath.Join(conf.Conf.TempDir, args.Tool, uid)
-	DeletePolicy := args.DeletePolicy
+	deletePolicy := args.DeletePolicy
 	if args.Tool == "pikpak" {
 		tempDir = args.DstDirPath
-		// 防止将下载好的
-		DeletePolicy = DeleteNever
+		// 防止将下载好的文件删除
+		deletePolicy = DeleteNever
 	}
 	t := &DownloadTask{
 		Url:          args.URL,
 		DstDirPath:   args.DstDirPath,
 		TempDir:      tempDir,
-		DeletePolicy: DeletePolicy,
+		DeletePolicy: deletePolicy,
 		tool:         tool,
 	}
 	DownloadTaskManager.Add(t)

--- a/internal/offline_download/tool/download.go
+++ b/internal/offline_download/tool/download.go
@@ -71,6 +71,9 @@ outer:
 	if err != nil {
 		return err
 	}
+	if t.tool.Name() == "pikpak" {
+		return nil
+	}
 	t.Status = "offline download completed, maybe transferring"
 	// hack for qBittorrent
 	if t.tool.Name() == "qBittorrent" {

--- a/internal/offline_download/tool/download.go
+++ b/internal/offline_download/tool/download.go
@@ -123,6 +123,9 @@ func (t *DownloadTask) Complete() error {
 		files []File
 		err   error
 	)
+	if t.tool.Name() == "pikpak" {
+		return nil
+	}
 	if getFileser, ok := t.tool.(GetFileser); ok {
 		files = getFileser.GetFiles(t)
 	} else {
@@ -132,7 +135,7 @@ func (t *DownloadTask) Complete() error {
 		}
 	}
 	// upload files
-	for i, _ := range files {
+	for i := range files {
 		file := files[i]
 		TransferTaskManager.Add(&TransferTask{
 			file:         file,


### PR DESCRIPTION
## 当前功能：
- 添加PikPak网盘之后，可以在挂载目录及其子目录下使用离线下载功能，支持的链接：`magnet`, `http`, `ed2k`，也支持Twitter、TikTok、Facebook、TG 的网址链接
- 不支持在其他类型网盘目录下使用PikPak离线功能，想要保存到其他位置可以手动复制

Closes #6632