### PR TITLE
Fix S3 Implementation bug & Support AWS Signature V2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Xhofe/go-cache v0.0.0-20220723083548-714439c8af9a
 	github.com/Xhofe/rateg v0.0.0-20230728072201-251a4e1adad4
 	github.com/Xhofe/wopan-sdk-go v0.1.2
-	github.com/alist-org/gofakes3 v0.0.4
+	github.com/alist-org/gofakes3 v0.0.5
 	github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.50.24

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/abbot/go-http-auth v0.4.0 h1:QjmvZ5gSC7jm3Zg54DqWE/T5m1t2AfDu6QlXJT0E
 github.com/abbot/go-http-auth v0.4.0/go.mod h1:Cz6ARTIzApMJDzh5bRMSUou6UMSp0IEXg9km/ci7TJM=
 github.com/aead/ecdh v0.2.0 h1:pYop54xVaq/CEREFEcukHRZfTdjiWvYIsZDXXrBapQQ=
 github.com/aead/ecdh v0.2.0/go.mod h1:a9HHtXuSo8J1Js1MwLQx2mBhkXMT6YwUmVVEY4tTB8U=
-github.com/alist-org/gofakes3 v0.0.4 h1:/ID4+1llsiB8EweLcC65rVmgBZKL95e3P7Wa+aJGUiE=
-github.com/alist-org/gofakes3 v0.0.4/go.mod h1:bLPZXt45XYMgaoGGLe5t0d1p13oZTQTptTEDLrku070=
+github.com/alist-org/gofakes3 v0.0.5 h1:bLHhLTNg3kIRdx7gsgi9Zg/EW9s3IHwJVRwzUCPR8V0=
+github.com/alist-org/gofakes3 v0.0.5/go.mod h1:6IyGtYGIX29fLvtXo+XZhtwX2P33KVYYj8uTgAHSu58=
 github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible h1:8psS8a+wKfiLt1iVDX79F7Y6wUM49Lcha2FMXt4UM8g=
 github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/andreburgaud/crypt2go v1.2.0 h1:oly/ENAodeqTYpUafgd4r3v+VKLQnmOKUyfpj+TxHbE=

--- a/server/s3/backend.go
+++ b/server/s3/backend.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"github.com/pkg/errors"
 	"io"
 	"path"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/alist-org/gofakes3"
 	"github.com/ncw/swift/v2"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -268,9 +270,19 @@ func (b *s3Backend) PutObject(
 	fp := path.Join(bucketPath, objectName)
 	reqPath := path.Dir(fp)
 	fmeta, _ := op.GetNearestMeta(fp)
-	_, err = fs.Get(context.WithValue(ctx, "meta", fmeta), reqPath, &fs.GetArgs{})
+	ctx = context.WithValue(ctx, "meta", fmeta)
+
+	_, err = fs.Get(ctx, reqPath, &fs.GetArgs{})
 	if err != nil {
-		return result, gofakes3.KeyNotFound(objectName)
+		if errs.IsObjectNotFound(err) && strings.Contains(objectName, "/") {
+			log.Debugf("reqPath: %s not found and objectName contains /, need to makeDir", reqPath)
+			err = fs.MakeDir(ctx, reqPath, true)
+			if err != nil {
+				return result, errors.WithMessagef(err, "failed to makeDir, reqPath: %s", reqPath)
+			}
+		} else {
+			return result, gofakes3.KeyNotFound(objectName)
+		}
 	}
 
 	var ti time.Time


### PR DESCRIPTION
This PR has 2 Commits:
* Fix the bug Alist S3 Implementation not support multi-level objectName(like aaa/bbb.txt) when PutObject.
* Upgrade gofakes3 to v0.0.5, which already supported AWS Signature V2.

Already tested by Seafile + Alist S3 + AliyunOpen backend storage.