### PR TITLE
chore: update polyfill URL due to service unavailability and supply chain attack risk

### DIFF
--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -131,7 +131,7 @@ func InitialSettings() []model.SettingItem {
 		// global settings
 		{Key: conf.HideFiles, Value: "/\\/README.md/i", Type: conf.TypeText, Group: model.GLOBAL},
 		{Key: "package_download", Value: "true", Type: conf.TypeBool, Group: model.GLOBAL},
-		{Key: conf.CustomizeHead, PreDefault: `<script src="https://polyfill.io/v3/polyfill.min.js?features=String.prototype.replaceAll"></script>`, Type: conf.TypeText, Group: model.GLOBAL, Flag: model.PRIVATE},
+		{Key: conf.CustomizeHead, PreDefault: `<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=String.prototype.replaceAll"></script>`, Type: conf.TypeText, Group: model.GLOBAL, Flag: model.PRIVATE},
 		{Key: conf.CustomizeBody, Type: conf.TypeText, Group: model.GLOBAL, Flag: model.PRIVATE},
 		{Key: conf.LinkExpiration, Value: "0", Type: conf.TypeNumber, Group: model.GLOBAL, Flag: model.PRIVATE},
 		{Key: conf.SignAll, Value: "true", Type: conf.TypeBool, Group: model.GLOBAL, Flag: model.PRIVATE},


### PR DESCRIPTION
The CDN service polyfill.io has recently been unavailable, and it [has been found to be used in implementing supply chain attack](https://www.origina.com/blog/security-alert-polyfill-io-supply-chain-attack), [related issue in polyfill repo](https://github.com/polyfillpolyfill/polyfill-service/issues/2892). The [GitHub repo](https://github.com/polyfillpolyfill/polyfill-service) of the polyfill service will now show a warning alert.

This PR changes the default polyfill url to use [cloudflare alternative endpoint](https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk), which can reduce the supply chain risk.