### PR TITLE
fix: ignore os.ErrClosed error on repeated FileStream close operations

### DIFF
--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -51,7 +51,11 @@ func (f *FileStream) IsForceStreamUpload() bool {
 
 func (f *FileStream) Close() error {
 	var err1, err2 error
+
 	err1 = f.Closers.Close()
+	if errors.Is(err1, os.ErrClosed) {
+		err1 = nil
+	}
 	if f.tmpFile != nil {
 		err2 = os.RemoveAll(f.tmpFile.Name())
 		if err2 != nil {


### PR DESCRIPTION
Additionally, this resolves the issue where S3's PutObject returns a 500 status code, as seen in:
https://github.com/alist-org/alist/blob/9e0482afbb0d3490cf3d98d79fbd0f75b9ac6349/server/s3/backend.go#L315-L319
It also mitigates log spam caused by repeated file closures, detailed here:
https://github.com/alist-org/alist/blob/9e0482afbb0d3490cf3d98d79fbd0f75b9ac6349/internal/op/fs.go#L501-L505

Already tested by Alist S3 + restic S3 + 123pan