### PR TITLE
fix(123pan): add warning for mismatched file count when listing files

### DIFF
--- a/drivers/123/driver.go
+++ b/drivers/123/driver.go
@@ -53,7 +53,7 @@ func (d *Pan123) Drop(ctx context.Context) error {
 }
 
 func (d *Pan123) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
-	files, err := d.getFiles(dir.GetID())
+	files, err := d.getFiles(dir.GetID(), dir.GetName())
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/123/types.go
+++ b/drivers/123/types.go
@@ -87,8 +87,9 @@ var _ model.Thumb = (*File)(nil)
 type Files struct {
 	//BaseResp
 	Data struct {
-		InfoList []File `json:"InfoList"`
 		Next     string `json:"Next"`
+		Total    int    `json:"Total"`
+		InfoList []File `json:"InfoList"`
 	} `json:"data"`
 }
 

--- a/drivers/123/util.go
+++ b/drivers/123/util.go
@@ -3,6 +3,7 @@ package _123
 import (
 	"errors"
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	"hash/crc32"
 	"math"
 	"math/rand"
@@ -232,8 +233,9 @@ func (d *Pan123) request(url string, method string, callback base.ReqCallback, r
 	return body, nil
 }
 
-func (d *Pan123) getFiles(parentId string) ([]File, error) {
+func (d *Pan123) getFiles(parentId string, name string) ([]File, error) {
 	page := 1
+	total := 0
 	res := make([]File, 0)
 	// 2024-02-06 fix concurrency by 123pan
 	for {
@@ -265,9 +267,13 @@ func (d *Pan123) getFiles(parentId string) ([]File, error) {
 		}
 		page++
 		res = append(res, resp.Data.InfoList...)
+		total = resp.Data.Total
 		if len(resp.Data.InfoList) == 0 || resp.Data.Next == "-1" {
 			break
 		}
+	}
+	if len(res) != total {
+		log.Warnf("incorrect file count from remote at %s: expected %d, got %d", name, total, len(res))
 	}
 	return res, nil
 }


### PR DESCRIPTION
Fixes an issue where using `file_name` order could result in incorrect file counts compared to response fields.

As shown in the image below, the actual number of files in the root directory is 3, but the API's response field indicates 4. In another directory, the actual file count is 933, yet the API has returned only 787 files.
![2024-07-19_12-12](https://github.com/user-attachments/assets/e3202e8a-c8a0-4969-b12e-f6f9a95f1dfc)

After switching to a different sorting method, everything works correctly. Therefore, I've only added a warning here.