### PR TITLE
fix(aliyundrive_open): add aliyundrive_tv auth

### DIFF
--- a/drivers/aliyundrive_open/driver.go
+++ b/drivers/aliyundrive_open/driver.go
@@ -42,6 +42,18 @@ func (d *AliyundriveOpen) Init(ctx context.Context) error {
 	if d.DriveType == "" {
 		d.DriveType = "default"
 	}
+	if d.UseTVAuth && d.RefreshToken == "" {
+		if d.SID != "" {
+			// 查询 对应的 authCode --> 获取 access_token refresh_token
+			err := d.getRefreshTokenBySID()
+			if err != nil {
+				return err
+			}
+		} else {
+			// 发送 qcode 请求 获取 sid
+			return d.getSID()
+		}
+	}
 	res, err := d.request("/adrive/v1.0/user/getDriveInfo", http.MethodPost, nil)
 	if err != nil {
 		return err

--- a/drivers/aliyundrive_open/meta.go
+++ b/drivers/aliyundrive_open/meta.go
@@ -8,7 +8,7 @@ import (
 type Addition struct {
 	DriveType string `json:"drive_type" type:"select" options:"default,resource,backup" default:"default"`
 	driver.RootID
-	RefreshToken       string `json:"refresh_token" required:"true"`
+	RefreshToken       string `json:"refresh_token"`
 	OrderBy            string `json:"order_by" type:"select" options:"name,size,updated_at,created_at"`
 	OrderDirection     string `json:"order_direction" type:"select" options:"ASC,DESC"`
 	OauthTokenURL      string `json:"oauth_token_url" default:"https://api.nn.ci/alist/ali_open/token"`
@@ -19,6 +19,8 @@ type Addition struct {
 	InternalUpload     bool   `json:"internal_upload" help:"If you are using Aliyun ECS is located in Beijing, you can turn it on to boost the upload speed"`
 	LIVPDownloadFormat string `json:"livp_download_format" type:"select" options:"jpeg,mov" default:"jpeg"`
 	AccessToken        string
+	UseTVAuth          bool   `json:"use_tv_auth"`
+	SID                string `json:"sid"`
 }
 
 var config = driver.Config{

--- a/drivers/aliyundrive_open/types.go
+++ b/drivers/aliyundrive_open/types.go
@@ -82,3 +82,30 @@ type MoveOrCopyResp struct {
 	DriveID string `json:"drive_id"`
 	FileID  string `json:"file_id"`
 }
+
+type SIDResp struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    struct {
+		QRCodeURL string `json:"qrCodeUrl"`
+		SID       string `json:"sid"`
+	} `json:"data"`
+}
+
+type RefreshTokenSIDResp struct {
+	Status   string `json:"status"`
+	AuthCode string `json:"authCode"`
+}
+
+type RefreshTokenAuthResp struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    struct {
+		Code         string `json:"code"`
+		Message      string `json:"message"`
+		TokenType    string `json:"token_type"`
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIN    int    `json:"expires_in"`
+	}
+}

--- a/drivers/aliyundrive_open/util.go
+++ b/drivers/aliyundrive_open/util.go
@@ -119,7 +119,11 @@ func (d *AliyundriveOpen) requestReturnErrResp(uri, method string, callback base
 	isRetry := len(retry) > 0 && retry[0]
 	if e.Code != "" {
 		if !isRetry && (utils.SliceContains([]string{"AccessTokenInvalid", "AccessTokenExpired", "I400JD"}, e.Code) || d.AccessToken == "") {
-			err = d.refreshToken()
+			if d.UseTVAuth {
+				err = d.getRefreshTokenByTV(d.RefreshToken, true)
+			} else {
+				err = d.refreshToken()
+			}
 			if err != nil {
 				return nil, err, nil
 			}
@@ -175,4 +179,90 @@ func getNowTime() (time.Time, string) {
 	nowTime := time.Now()
 	nowTimeStr := nowTime.Format("2006-01-02T15:04:05.000Z")
 	return nowTime, nowTimeStr
+}
+
+func (d *AliyundriveOpen) getSID() error {
+	url := "http://api.extscreen.com/aliyundrive/qrcode"
+	var resp SIDResp
+	_, err := base.RestyClient.R().
+		SetBody(base.Json{
+			"scopes": "user:base,file:all:read,file:all:write",
+			"width":  500,
+			"height": 500,
+		}).
+		SetResult(&resp).
+		Post(url)
+	if err != nil {
+		return err
+	}
+	d.SID = resp.Data.SID
+	op.MustSaveDriverStorage(d)
+	authURL := fmt.Sprintf("https://www.aliyundrive.com/o/oauth/authorize?sid=%s", resp.Data.SID)
+	return fmt.Errorf(`need verify: <a target="_blank" href="%s">Click Here</a>`, authURL)
+}
+
+func (d *AliyundriveOpen) getRefreshTokenBySID() error {
+	// 获取 authCode
+	authCode := ""
+	url := "https://openapi.alipan.com/oauth/qrcode/" + d.SID + "/status"
+	time.Sleep(time.Second) // 等待 阿里云盘那边更新SID状态
+	var resp RefreshTokenSIDResp
+	_, err := base.RestyClient.R().
+		SetResult(&resp).
+		Get(url)
+	if err != nil {
+		return err
+	}
+	if resp.Status != "LoginSuccess" {
+		return fmt.Errorf("failed to get auth code: %s", resp.Status)
+
+	} else {
+		authCode = resp.AuthCode
+	}
+	return d.getRefreshTokenByTV(authCode, false)
+}
+
+func (d *AliyundriveOpen) getRefreshTokenByTV(code string, isRefresh bool) error {
+	refresh, access, err := d._getRefreshTokenByTV(code, isRefresh)
+	for i := 0; i < 3; i++ {
+		if err == nil {
+			break
+		} else {
+			log.Errorf("[ali_open] failed to refresh token: %s", err)
+		}
+		refresh, access, err = d._getRefreshTokenByTV(code, isRefresh)
+	}
+	if err != nil {
+		return err
+	}
+	log.Infof("[ali_open] token exchange: %s -> %s", d.RefreshToken, refresh)
+	d.RefreshToken, d.AccessToken = refresh, access
+	op.MustSaveDriverStorage(d)
+	return nil
+}
+
+func (d *AliyundriveOpen) _getRefreshTokenByTV(code string, isRefresh bool) (refreshToken, accessToken string, err error) {
+	url := "http://api.extscreen.com/aliyundrive/token"
+	var resp RefreshTokenAuthResp
+	body := ""
+	if isRefresh {
+		body = fmt.Sprintf("refresh_token=%s", code)
+	} else {
+		body = fmt.Sprintf("code=%s", code)
+	}
+
+	res, err := base.RestyClient.R().
+		SetHeader("Content-Type", "application/x-www-form-urlencoded").
+		SetBody(body).
+		SetResult(&resp).
+		Post(url)
+	if err != nil {
+		return "", "", err
+	}
+
+	refresh, access := resp.Data.RefreshToken, resp.Data.AccessToken
+	if refresh == "" {
+		return "", "", fmt.Errorf("failed to refresh token: refresh token is empty, resp: %s", res.String())
+	}
+	return refresh, access, nil
 }


### PR DESCRIPTION
### 说明
> 该接口来自 阿里云盘官网的  [TV版本](https://www.alipan.com/download/tvdownload)
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/6419caf5-567c-4652-a850-25488aedf62f">

---

### 改动
- 添加了 `Use tv auth` 选项，用户可以选择是否使用 `TV端` 接口
- 添加了 `Sid` 配置项，该配置项仅用于 `TV端` 获取 `Refresh Token`，无需手动填写
- 修改了 `Refresh token` ，使其不再成为必填项 --- 使用 `TV端` 接口时，无需手动填写 `Refresh Token`

---

### 使用方法（使用 `TV` 端口 情况）
1.  初次配置时，仅需打开 `Use tv auth` 选项后保存 ，无需填写 `Refresh token`、`Oauth token url`、`Client id`、`Client secret` 
> 此时右上角会弹出：
> <img width="324" alt="image" src="https://github.com/user-attachments/assets/c4efd2ff-b778-46b2-bd86-8a71b48ed2a2">
> 此时返回 存储页面，之前添加的驱动应该如下图所示：
> <img width="278" alt="image" src="https://github.com/user-attachments/assets/0d8989ab-7452-4015-8c05-406e383606af">
> 点击 `Click Here`，会进入 `阿里云盘TV `的授权页面，如下图所示
> <img width="328" alt="image" src="https://github.com/user-attachments/assets/bb3fc752-90d9-4bd0-b8d2-ff6a5675015e">
> 授权后，返回 `Alist` 存储页面

2. 禁用之前添加的驱动，并重新启用，此时驱动应该正常工作，enjoy~


**注意** 如果出现下面的报错信息，请 **清空 `SID` 配置项的内容，并重新保存**
> <img width="289" alt="image" src="https://github.com/user-attachments/assets/0c91ee64-e615-4f9e-b572-88ccfd469fbd">

> 原因：授权后，未及时保存驱动，`SID`已经失效

---

### 为什么要添加 `TV`版接口 / 有什么用？
1. 虽然同样属于第三方应用授权，但官方对该应用并不计算进 `高速下载流量` ，也就是说 不消耗 `三方权益包` 流量
2. 同样存在线程数限制（4）
3. 非 `SVIP` + 无 `三方权益包` ，同样限速，大概 `2MB`左右
4. `SVIP` + `无三方权益包`，不限速 ———— （测试时，送的10G高速下载流量未使用）
5. 其他情况未测试，待补充

---
> 附上速度测试
> 非 `SVIP` + 无 `三方权益包` ：<img width="242" alt="image" src="https://github.com/user-attachments/assets/58a55fbf-a16a-45ba-87b1-b3c70a906ff3">
> `SVIP` + `无三方权益包` ：<img width="272" alt="image" src="https://github.com/user-attachments/assets/059f484f-1bdb-4d95-b47f-eb58545d0ca7">
