### PR TITLE
feature: server id support

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -71,6 +71,7 @@ type S3 struct {
 }
 
 type Config struct {
+	ServerId              string      `json:"server_id" env:"SERVER_ID"`
 	Force                 bool        `json:"force" env:"FORCE"`
 	SiteURL               string      `json:"site_url" env:"SITE_URL"`
 	Cdn                   string      `json:"cdn" env:"CDN"`

--- a/internal/model/storage.go
+++ b/internal/model/storage.go
@@ -4,6 +4,7 @@ import "time"
 
 type Storage struct {
 	ID              uint      `json:"id" gorm:"primaryKey"`                        // unique key
+	ServerId        string    `json:"server_id"`                                   // only effective if driver is "Local"
 	MountPath       string    `json:"mount_path" gorm:"unique" binding:"required"` // must be standardized
 	Order           int       `json:"order"`                                       // use to sort
 	Driver          string    `json:"driver"`                                      // driver used

--- a/internal/op/storage.go
+++ b/internal/op/storage.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/db"
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/model"
@@ -51,6 +52,10 @@ func CreateStorage(ctx context.Context, storage model.Storage) (uint, error) {
 		return 0, errors.WithMessage(err, "failed get driver new")
 	}
 	storageDriver := driverNew()
+	//if server_id is not empty,set the local storage server id
+	if driverName == "Local" && len(conf.Conf.ServerId) > 0 {
+		storage.ServerId = conf.Conf.ServerId
+	}
 	// insert storage to database
 	err = db.CreateStorage(&storage)
 	if err != nil {
@@ -165,6 +170,9 @@ func UpdateStorage(ctx context.Context, storage model.Storage) error {
 	}
 	storage.Modified = time.Now()
 	storage.MountPath = utils.FixAndCleanPath(storage.MountPath)
+	if storage.Driver == "Local" && len(conf.Conf.ServerId) > 0 {
+		storage.ServerId = conf.Conf.ServerId
+	}
 	err = db.UpdateStorage(&storage)
 	if err != nil {
 		return errors.WithMessage(err, "failed update storage in database")

--- a/server/handles/auth.go
+++ b/server/handles/auth.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Xhofe/go-cache"
+	"github.com/alist-org/alist/v3/internal/conf"
 	"github.com/alist-org/alist/v3/internal/model"
 	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/alist-org/alist/v3/server/common"
@@ -89,7 +90,8 @@ func loginHash(c *gin.Context, req *LoginReq) {
 
 type UserResp struct {
 	model.User
-	Otp bool `json:"otp"`
+	Otp      bool   `json:"otp"`
+	ServerId string `json:"server_id"`
 }
 
 // CurrentUser get current user by token
@@ -97,7 +99,8 @@ type UserResp struct {
 func CurrentUser(c *gin.Context) {
 	user := c.MustGet("user").(*model.User)
 	userResp := UserResp{
-		User: *user,
+		User:     *user,
+		ServerId: conf.Conf.ServerId,
 	}
 	userResp.Password = ""
 	if userResp.OtpSecret != "" {


### PR DESCRIPTION
配置文件增加server_id字段，用于区分多服务环境下，当前服务的id。本次pr实现了多服务同时挂载本地存储，挂载目录和存储状态能够正确展示的功能。
关联issue: [多个alist服务共用一个mysql数据库](https://github.com/alist-org/alist/issues/6828)