### PR TITLE
ci(docker): using docker build args instead of extra dockerfile for ffmpeg

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -74,19 +74,16 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x
 
-      - name: Replace dockerfile tag
-        run: |
-          sed -i -e "s/latest/main/g" Dockerfile.ffmpeg
-
       - name: Build and push with ffmpeg
         id: docker_build_ffmpeg
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: Dockerfile.ffmpeg
+          file: Dockerfile.ci
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta-ffmpeg.outputs.tags }}
           labels: ${{ steps.meta-ffmpeg.outputs.labels }}
+          build-args: INSTALL_FFMPEG=true
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x
 
   build_docker_with_aria2:

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -74,10 +74,11 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: Dockerfile.ffmpeg
+          file: Dockerfile.ci
           push: true
           tags: ${{ steps.meta-ffmpeg.outputs.tags }}
           labels: ${{ steps.meta-ffmpeg.outputs.labels }}
+          build-args: INSTALL_FFMPEG=true
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/arm/v6,linux/s390x
 
   release_docker_with_aria2:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,23 @@ COPY ./ ./
 RUN bash build.sh release docker
 
 FROM alpine:edge
+
+ARG FFMPEG=false
 LABEL MAINTAINER="i@nn.ci"
-VOLUME /opt/alist/data/
+
 WORKDIR /opt/alist/
-COPY --from=builder /app/bin/alist ./
-COPY entrypoint.sh /entrypoint.sh
+
 RUN apk update && \
     apk upgrade --no-cache && \
     apk add --no-cache bash ca-certificates su-exec tzdata; \
-    chmod +x /entrypoint.sh && \
+    [ "$FFMPEG" = "true" ] && apk add --no-cache ffmpeg; \
     rm -rf /var/cache/apk/*
+
+COPY --from=builder /app/bin/alist ./
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh && /entrypoint.sh version
+
 ENV PUID=0 PGID=0 UMASK=022
+VOLUME /opt/alist/data/
 EXPOSE 5244 5245
 CMD [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN bash build.sh release docker
 
 FROM alpine:edge
 
-ARG FFMPEG=false
+ARG INSTALL_FFMPEG=false
 LABEL MAINTAINER="i@nn.ci"
 
 WORKDIR /opt/alist/
@@ -17,7 +17,7 @@ WORKDIR /opt/alist/
 RUN apk update && \
     apk upgrade --no-cache && \
     apk add --no-cache bash ca-certificates su-exec tzdata; \
-    [ "$FFMPEG" = "true" ] && apk add --no-cache ffmpeg; \
+    [ "$INSTALL_FFMPEG" = "true" ] && apk add --no-cache ffmpeg; \
     rm -rf /var/cache/apk/*
 
 COPY --from=builder /app/bin/alist ./

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,16 +1,22 @@
 FROM alpine:edge
+
 ARG TARGETPLATFORM
+ARG FFMPEG=false
 LABEL MAINTAINER="i@nn.ci"
-VOLUME /opt/alist/data/
+
 WORKDIR /opt/alist/
-COPY /build/${TARGETPLATFORM}/alist ./
-COPY entrypoint.sh /entrypoint.sh
+
 RUN apk update && \
     apk upgrade --no-cache && \
     apk add --no-cache bash ca-certificates su-exec tzdata; \
-    chmod +x /entrypoint.sh && \
-    rm -rf /var/cache/apk/* && \
-    /entrypoint.sh version
+    [ "$FFMPEG" = "true" ] && apk add --no-cache ffmpeg; \
+    rm -rf /var/cache/apk/*
+
+COPY /build/${TARGETPLATFORM}/alist ./
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh && /entrypoint.sh version
+
 ENV PUID=0 PGID=0 UMASK=022
+VOLUME /opt/alist/data/
 EXPOSE 5244 5245
 CMD [ "/entrypoint.sh" ]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,7 +1,7 @@
 FROM alpine:edge
 
 ARG TARGETPLATFORM
-ARG FFMPEG=false
+ARG INSTALL_FFMPEG=false
 LABEL MAINTAINER="i@nn.ci"
 
 WORKDIR /opt/alist/
@@ -9,7 +9,7 @@ WORKDIR /opt/alist/
 RUN apk update && \
     apk upgrade --no-cache && \
     apk add --no-cache bash ca-certificates su-exec tzdata; \
-    [ "$FFMPEG" = "true" ] && apk add --no-cache ffmpeg; \
+    [ "$INSTALL_FFMPEG" = "true" ] && apk add --no-cache ffmpeg; \
     rm -rf /var/cache/apk/*
 
 COPY /build/${TARGETPLATFORM}/alist ./

--- a/Dockerfile.ffmpeg
+++ b/Dockerfile.ffmpeg
@@ -1,4 +1,0 @@
-FROM xhofe/alist:latest
-RUN apk update && \
-    apk add --no-cache ffmpeg \
-    rm -rf /var/cache/apk/*


### PR DESCRIPTION
This change makes building Docker images more flexible for sub-versions or forked versions. Additionally, this PR reduces the number of Docker image layers and increases the cache hit rate for CI.

Test Images: [v3.36.0-alpha6](https://hub.docker.com/layers/mmx233/alist/v3.36.0-alpha6/images/sha256-9d9ec0de0e6da1341c63af68d08521aea5ffc96c9e7fb371fd299389c8f6d695?context=repo), [v3.36.0-alpha6-ffmpeg](https://hub.docker.com/layers/mmx233/alist/v3.36.0-alpha6-ffmpeg/images/sha256-4a0e8fdfe3de83490a8511a274444b5e72296de52393ecf6a50346b8e0c12c6a?context=repo)

Test Actions: [release_docker](https://github.com/Mmx233/alist/actions/runs/10339850804)