### PR TITLE
fix(pikpak): fix the problem that refresh_token cannot be obtained

### DIFF
--- a/drivers/pikpak/meta.go
+++ b/drivers/pikpak/meta.go
@@ -11,6 +11,8 @@ type Addition struct {
 	Password         string `json:"password" required:"true"`
 	ClientID         string `json:"client_id" required:"true" default:"YNxT9w7GMdWvEOKa"`
 	ClientSecret     string `json:"client_secret" required:"true" default:"dbw2OtmVEeuUvIptb1Coyg"`
+	RefreshToken     string `json:"refresh_token" required:"true" default:""`
+	CaptchaToken     string `json:"captcha_token" default:""`
 	DisableMediaLink bool   `json:"disable_media_link"`
 }
 


### PR DESCRIPTION
### 改动
- 移除了  `oauth2`  的登录方式，改为普通请求（需要携带 `captcha_token`）
> 原因：现在使用 `oauth2` 进行登录时，会返回错误提示：
``` json
{
  "error": "invalid_argument",
  "error_code": 3,
  "error_description": "currently not supported",
  "details": []
}
```

- 跟随官方版本，更新了部分客户端参数（Algorithms）
- 为 `request` 函数添加了 `User-Agent`、`X-Device-ID`、`X-Captcha-Token` 参数
- 添加了 `refresh_token` 字段，用户可自行抓包填写，也可以留空，会自动生成
- 添加了 `captcha_token` 字段，无需手动填写

---

#### 如果登录时有出现 `failed get objs: failed to list objs: need verify:  < --------a target="_blank" href` 这样的错误，是触发了风控
> 需要**点击链接**，进行滑动验证码验证，验证完成后，请**禁用添加的驱动并重新启用**，此时驱动应该正常工作
> 或者自行抓包，获取 `Refresh Token` 并填入对应字段