### PR TITLE
fix(pikpak): modify the processing logic of CaptchaToken

### DIFF
--- a/drivers/pikpak/driver.go
+++ b/drivers/pikpak/driver.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/alist-org/alist/v3/internal/op"
+	"golang.org/x/oauth2"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -28,6 +30,7 @@ type PikPak struct {
 	*Common
 	RefreshToken string
 	AccessToken  string
+	oauth2Token  oauth2.TokenSource
 }
 
 func (d *PikPak) Config() driver.Config {
@@ -39,10 +42,6 @@ func (d *PikPak) GetAddition() driver.Additional {
 }
 
 func (d *PikPak) Init(ctx context.Context) (err error) {
-	if d.ClientID == "" || d.ClientSecret == "" {
-		d.ClientID = "YNxT9w7GMdWvEOKa"
-		d.ClientSecret = "dbw2OtmVEeuUvIptb1Coyg"
-	}
 
 	if d.Common == nil {
 		d.Common = &Common{
@@ -50,7 +49,7 @@ func (d *PikPak) Init(ctx context.Context) (err error) {
 			CaptchaToken: "",
 			UserID:       "",
 			DeviceID:     utils.GetMD5EncodeStr(d.Username + d.Password),
-			UserAgent:    BuildCustomUserAgent(utils.GetMD5EncodeStr(d.Username+d.Password), ClientID, PackageName, SdkVersion, ClientVersion, PackageName, ""),
+			UserAgent:    "",
 			RefreshCTokenCk: func(token string) {
 				d.Common.CaptchaToken = token
 				op.MustSaveDriverStorage(d)
@@ -58,21 +57,70 @@ func (d *PikPak) Init(ctx context.Context) (err error) {
 		}
 	}
 
+	if d.Platform == "android" {
+		d.ClientID = AndroidClientID
+		d.ClientSecret = AndroidClientSecret
+		d.ClientVersion = AndroidClientVersion
+		d.PackageName = AndroidPackageName
+		d.Algorithms = AndroidAlgorithms
+		d.UserAgent = BuildCustomUserAgent(utils.GetMD5EncodeStr(d.Username+d.Password), AndroidClientID, AndroidPackageName, AndroidSdkVersion, AndroidClientVersion, AndroidPackageName, "")
+	} else if d.Platform == "web" {
+		d.ClientID = WebClientID
+		d.ClientSecret = WebClientSecret
+		d.ClientVersion = WebClientVersion
+		d.PackageName = WebPackageName
+		d.Algorithms = WebAlgorithms
+		d.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36"
+	}
+
 	if d.Addition.CaptchaToken != "" && d.Addition.RefreshToken == "" {
 		d.SetCaptchaToken(d.Addition.CaptchaToken)
 	}
 
-	// 如果已经有RefreshToken，直接刷新AccessToken
-	if d.Addition.RefreshToken != "" {
-		d.RefreshToken = d.Addition.RefreshToken
-		if err := d.refreshToken(); err != nil {
-			return err
-		}
+	if d.Addition.DeviceID != "" {
+		d.SetDeviceID(d.Addition.DeviceID)
 	} else {
+		d.Addition.DeviceID = d.Common.DeviceID
+		op.MustSaveDriverStorage(d)
+	}
+	// 初始化 oauth2Config
+	oauth2Config := &oauth2.Config{
+		ClientID:     d.ClientID,
+		ClientSecret: d.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://user.mypikpak.com/v1/auth/signin",
+			TokenURL:  "https://user.mypikpak.com/v1/auth/token",
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+
+	// 如果已经有RefreshToken，直接获取AccessToken
+	if d.Addition.RefreshToken != "" {
+		// 使用 oauth2 刷新令牌
+		// 初始化 oauth2Token
+		d.oauth2Token = oauth2.ReuseTokenSource(nil, utils.TokenSource(func() (*oauth2.Token, error) {
+			return oauth2Config.TokenSource(ctx, &oauth2.Token{
+				RefreshToken: d.Addition.RefreshToken,
+			}).Token()
+		}))
+	} else {
+		// 如果没有填写RefreshToken，尝试登录 获取 refreshToken
 		if err := d.login(); err != nil {
 			return err
 		}
+		d.oauth2Token = oauth2.ReuseTokenSource(nil, utils.TokenSource(func() (*oauth2.Token, error) {
+			return oauth2Config.TokenSource(ctx, &oauth2.Token{
+				RefreshToken: d.RefreshToken,
+			}).Token()
+		}))
 	}
+
+	token, err := d.oauth2Token.Token()
+	if err != nil {
+		return err
+	}
+	d.RefreshToken = token.RefreshToken
+	d.AccessToken = token.AccessToken
 
 	// 获取CaptchaToken
 	err = d.RefreshCaptchaTokenAtLogin(GetAction(http.MethodGet, "https://api-drive.mypikpak.com/drive/v1/files"), d.Common.UserID)
@@ -80,7 +128,13 @@ func (d *PikPak) Init(ctx context.Context) (err error) {
 		return err
 	}
 	// 更新UserAgent
-	d.Common.UserAgent = BuildCustomUserAgent(d.Common.DeviceID, ClientID, PackageName, SdkVersion, ClientVersion, PackageName, d.Common.UserID)
+	if d.Platform == "android" {
+		d.Common.UserAgent = BuildCustomUserAgent(utils.GetMD5EncodeStr(d.Username+d.Password), AndroidClientID, AndroidPackageName, AndroidSdkVersion, AndroidClientVersion, AndroidPackageName, d.Common.UserID)
+	}
+
+	// 保存 有效的 RefreshToken
+	d.Addition.RefreshToken = d.RefreshToken
+	op.MustSaveDriverStorage(d)
 	return nil
 }
 
@@ -100,8 +154,18 @@ func (d *PikPak) List(ctx context.Context, dir model.Obj, args model.ListArgs) (
 
 func (d *PikPak) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	var resp File
-	_, err := d.request(fmt.Sprintf("https://api-drive.mypikpak.com/drive/v1/files/%s?_magic=2021&thumbnail_size=SIZE_LARGE", file.GetID()),
-		http.MethodGet, nil, &resp)
+	queryParams := map[string]string{
+		"_magic":         "2021",
+		"usage":          "FETCH",
+		"thumbnail_size": "SIZE_LARGE",
+	}
+	if !d.DisableMediaLink {
+		queryParams["usage"] = "CACHE"
+	}
+	_, err := d.request(fmt.Sprintf("https://api-drive.mypikpak.com/drive/v1/files/%s", file.GetID()),
+		http.MethodGet, func(req *resty.Request) {
+			req.SetQueryParams(queryParams)
+		}, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +288,7 @@ func (d *PikPak) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 	input := &s3manager.UploadInput{
 		Bucket: &params.Bucket,
 		Key:    &params.Key,
-		Body:   stream,
+		Body:   io.TeeReader(stream, driver.NewProgress(stream.GetSize(), up)),
 	}
 	_, err = uploader.UploadWithContext(ctx, input)
 	return err

--- a/drivers/pikpak/meta.go
+++ b/drivers/pikpak/meta.go
@@ -9,11 +9,11 @@ type Addition struct {
 	driver.RootID
 	Username         string `json:"username" required:"true"`
 	Password         string `json:"password" required:"true"`
-	ClientID         string `json:"client_id" required:"true" default:"YNxT9w7GMdWvEOKa"`
-	ClientSecret     string `json:"client_secret" required:"true" default:"dbw2OtmVEeuUvIptb1Coyg"`
+	Platform         string `json:"platform" required:"true" type:"select" options:"android,web"`
 	RefreshToken     string `json:"refresh_token" required:"true" default:""`
 	CaptchaToken     string `json:"captcha_token" default:""`
-	DisableMediaLink bool   `json:"disable_media_link"`
+	DeviceID         string `json:"device_id"  required:"false" default:""`
+	DisableMediaLink bool   `json:"disable_media_link" default:"true"`
 }
 
 var config = driver.Config{


### PR DESCRIPTION
### 改动
- 修复了部分错误信息未被正确处理的BUG————现在可正常显示 ~~`被风控后的滑动验证地址`~~
- 修改了 `CaptchaToken` 的处理逻辑
- 调整了 `Link` 函数的部分参数
- 现在 `DisableMediaLink` 选项将默认开启————可以避免出现 #4735 的问题
- 尝试为上传添加 `进度显示`
- 移除了 `client_id`、`client_secret` 字段
- 添加了 `DeviceID` 字段
- 添加了 `Platform` 选择项：可选 `android`、`web`
- 添加了 `Web` 端的 `ClientID`、`ClientSecret`、`ClientVersion`、`PackageName`、`WebAlgorithms`

---

### 部分参数解释
- `Username`：登录邮箱
- `Password`：登录密码
- `Platform`：选择 登录平台：安卓（android）| 网页（web）
- `Refresh token`：刷新令牌——手动填写后则无需填入账号密码登录（最好还是填一下），需抓包获取或登录后自动填入
- `Captcha token`：验证码令牌——**仅需要在触发风控时填写**，具体获取方式见下文
- `Device id`：设备ID——一般情况下无需修改，根据`Username`和`Password`字段的内容进行生成
- `Disable media link`：禁用媒体链接——关闭后将使用媒体地址，可能出现无法访问非媒体文件的情况

---

#### 部分问题说明
- 如果出现下图情况：
<img width="335" alt="image" src="https://github.com/user-attachments/assets/99b72292-f52e-4e9d-8171-4380f57da728"> 
 说明访问过于频繁，该账号/IP将在一段时间内无法登录。

> 注意：出现此情况后，**使用第三方授权可正常登录官方客户端**。同时，**使用该IP请求任何账号都有几率再次出现此问题**，可尝试使用`Refresh token`方式登录（不保证有效）

- 如果出现 `Click Here` 提示：
> 请点击进入，然后先打开F12或启动抓包软件，然后完成滑动验证码，如下图所示，获取`captcha_token`，填入驱动的`Captcha token`字段后，保存，此时驱动应该正常工作——**适用于使用账号密码登录的情况**
> 
<img width="1205" alt="image" src="https://github.com/user-attachments/assets/37db2fbd-fe25-4f46-bc23-890ed09b6a4e">

- 如果出现下面的报错：`invalid refresh token for it may be has been refreshed by other process, more info redis: nil`
> 情况一： 则表明 `Refresh token` 无效，请重新获取
> 情况二：`Platform`：选择错误，请更换选项

- `Web端 Refresh token` 的获取：
> 在官方网页登录后，打开F12控制台，进入下图中的页面（以 `Chrome` 为例）
> <img width="1004" alt="image" src="https://github.com/user-attachments/assets/da7b9cdd-97cb-4896-b285-d77e67340daf">

> 找到以`credentials`开头的选项，选中后，观察下方的信息栏，从中可以获取到`Refresh token`，如下图所示

> <img width="170" alt="image" src="https://github.com/user-attachments/assets/246682a8-ddcf-40d2-a966-0d9f37da3745">

- `Platform`选择问题：
> 如果选择 `android`，则会模拟 安卓客户端 进行访问，如果想使用 `Refresh token` 进行登录，请对 `官方安卓端APP` 进行抓包

> 如果选择 `web`，则会模拟 官方网页端 进行访问，如果想使用 `Refresh token` 进行登录，请使用 `Web端` 获取的 `Refresh token`

#### 部分已知问题
- 自动构建版本目前不会自动创建 `temp文件夹` ，在使用 `Stream`方式上传时可能会遇到问题，可改用`Form`方式上传或者~~手动建立该文件夹，位于`data/temp`~~

---

#### 更新
- 现在调整为使用 `oauth2` 方式来进行令牌的刷新
- 账号、密码 现在仅用于登录来获取 `Refresh token` 以及 `DeviceID` 的生成
- 遇到 `Your operation is too frequent, please try again later` 问题时，请尝试**在 `官方网页版` 或 `官方安卓端APP` 使用第三方授权**（例如：谷歌授权登录）进行登录，之后**获取 `Refresh token` 进行挂载**————注意 此时`Platform`的选用