### PR TITLE
fix(search): BuildIndex concurrency error

### DIFF
--- a/internal/errs/search.go
+++ b/internal/errs/search.go
@@ -3,5 +3,6 @@ package errs
 import "fmt"
 
 var (
-	SearchNotAvailable = fmt.Errorf("search not available")
+	SearchNotAvailable  = fmt.Errorf("search not available")
+	BuildIndexIsRunning = fmt.Errorf("build index is running, please try later")
 )

--- a/internal/op/fs.go
+++ b/internal/op/fs.go
@@ -136,9 +136,7 @@ func List(ctx context.Context, storage driver.Driver, path string, args model.Li
 		model.WrapObjsName(files)
 		// call hooks
 		go func(reqPath string, files []model.Obj) {
-			for _, hook := range objsUpdateHooks {
-				hook(reqPath, files)
-			}
+			HandleObjsUpdateHook(reqPath, files)
 		}(utils.GetFullPath(storage.GetStorage().MountPath, path), files)
 
 		// sort objs

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -27,7 +27,7 @@ func Init(mode string) error {
 		}
 		instance = nil
 	}
-	if Running.Load() {
+	if Running() {
 		return fmt.Errorf("index is running")
 	}
 	if mode == "none" {

--- a/pkg/mq/mq.go
+++ b/pkg/mq/mq.go
@@ -57,5 +57,7 @@ func (mq *inMemoryMQ[T]) Clear() {
 }
 
 func (mq *inMemoryMQ[T]) Len() int {
+	mq.Lock()
+	defer mq.Unlock()
 	return mq.queue.Len()
 }


### PR DESCRIPTION
Check Running and store true is not an atomic operation, Quit and Running will be wrong variable when StopIndex and UpdateIndex called from http api or index auto_update enabled, leading to goroutine leak, alist log is full of index log:
![image](https://github.com/user-attachments/assets/606b2785-ae79-4a38-97e9-a9a5cd911f89)
<img width="850" alt="屏幕截图 2024-08-18 120329" src="https://github.com/user-attachments/assets/ddd9b7e1-67b1-4db9-9fa7-adcfb4d2ce81">

I removed Running variable, use Quit pointer to check BuildIndex is running, intruducing local running variable to notify WalkDir stop running, make sure only one goroutine is running BuildIndex.