### PR TITLE
Fix os.create failure, while the name of downloaded file is empty in offline_download

### DIFF
--- a/internal/offline_download/http/client.go
+++ b/internal/offline_download/http/client.go
@@ -2,14 +2,16 @@ package http
 
 import (
 	"fmt"
-	"github.com/alist-org/alist/v3/internal/model"
-	"github.com/alist-org/alist/v3/internal/offline_download/tool"
-	"github.com/alist-org/alist/v3/pkg/utils"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
+
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/offline_download/tool"
+	"github.com/alist-org/alist/v3/pkg/utils"
 )
 
 type SimpleHttp struct {
@@ -63,7 +65,12 @@ func (s SimpleHttp) Run(task *tool.DownloadTask) error {
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("http status code %d", resp.StatusCode)
 	}
-	filename := path.Base(_u.Path)
+	// If Path is empty, use Hostname; otherwise, filePath euqals TempDir which causes os.Create to fail
+	urlPath := _u.Path
+	if urlPath == "" {
+		urlPath = strings.ReplaceAll(_u.Host, ".", "_")
+	}
+	filename := path.Base(urlPath)
 	if n, err := parseFilenameFromContentDisposition(resp.Header.Get("Content-Disposition")); err == nil {
 		filename = n
 	}


### PR DESCRIPTION
Offline download with the SimpleHttp tool parses the filename from the requesting URL. However, if the path in the URL is empty, the filename is also empty (which is then transformed into ‘.’ by path.Base). 
If the filename is empty, TempDir is set to the filename. Alist creates TempDir successfully, but os.Create fails to create the target file. 
To resolve this, I assign a default name to the temp file based on the hostname, replacing all dots with underscores. This ensures that TempDir and the filename are never equal.