### PR TITLE
fix(pikpak):fix webdav upload issue

### DIFF
--- a/drivers/pikpak/driver.go
+++ b/drivers/pikpak/driver.go
@@ -4,24 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/alist-org/alist/v3/internal/op"
-	"golang.org/x/oauth2"
-	"io"
-	"net/http"
-	"strconv"
-	"strings"
-
 	"github.com/alist-org/alist/v3/drivers/base"
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	hash_extend "github.com/alist-org/alist/v3/pkg/utils/hash"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/go-resty/resty/v2"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+	"net/http"
+	"strconv"
+	"strings"
 )
 
 type PikPak struct {
@@ -123,9 +117,15 @@ func (d *PikPak) Init(ctx context.Context) (err error) {
 	d.AccessToken = token.AccessToken
 
 	// 获取CaptchaToken
-	err = d.RefreshCaptchaTokenAtLogin(GetAction(http.MethodGet, "https://api-drive.mypikpak.com/drive/v1/files"), d.Common.UserID)
+	err = d.RefreshCaptchaTokenAtLogin(GetAction(http.MethodGet, "https://api-drive.mypikpak.com/drive/v1/files"), d.Username)
 	if err != nil {
 		return err
+	}
+
+	// 获取用户ID
+	userID := token.Extra("sub").(string)
+	if userID != "" {
+		d.Common.SetUserID(userID)
 	}
 	// 更新UserAgent
 	if d.Platform == "android" {
@@ -271,27 +271,17 @@ func (d *PikPak) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 	}
 
 	params := resp.Resumable.Params
-	endpoint := strings.Join(strings.Split(params.Endpoint, ".")[1:], ".")
-	cfg := &aws.Config{
-		Credentials: credentials.NewStaticCredentials(params.AccessKeyID, params.AccessKeySecret, params.SecurityToken),
-		Region:      aws.String("pikpak"),
-		Endpoint:    &endpoint,
+	//endpoint := strings.Join(strings.Split(params.Endpoint, ".")[1:], ".")
+	// web 端上传 返回的endpoint 为 `mypikpak.com` | android 端上传 返回的endpoint 为 `vip-lixian-07.mypikpak.com`·
+	if d.Addition.Platform == "android" {
+		params.Endpoint = "mypikpak.com"
 	}
-	ss, err := session.NewSession(cfg)
-	if err != nil {
-		return err
+
+	if stream.GetSize() <= 10*utils.MB { // 文件大小 小于10MB，改用普通模式上传
+		return d.UploadByOSS(&params, stream, up)
 	}
-	uploader := s3manager.NewUploader(ss)
-	if stream.GetSize() > s3manager.MaxUploadParts*s3manager.DefaultUploadPartSize {
-		uploader.PartSize = stream.GetSize() / (s3manager.MaxUploadParts - 1)
-	}
-	input := &s3manager.UploadInput{
-		Bucket: &params.Bucket,
-		Key:    &params.Key,
-		Body:   io.TeeReader(stream, driver.NewProgress(stream.GetSize(), up)),
-	}
-	_, err = uploader.UploadWithContext(ctx, input)
-	return err
+	// 分片上传
+	return d.UploadByMultipart(&params, stream.GetSize(), stream, up)
 }
 
 // 离线下载文件

--- a/drivers/pikpak/types.go
+++ b/drivers/pikpak/types.go
@@ -80,20 +80,22 @@ type UploadTaskData struct {
 	UploadType string `json:"upload_type"`
 	//UPLOAD_TYPE_RESUMABLE
 	Resumable *struct {
-		Kind   string `json:"kind"`
-		Params struct {
-			AccessKeyID     string    `json:"access_key_id"`
-			AccessKeySecret string    `json:"access_key_secret"`
-			Bucket          string    `json:"bucket"`
-			Endpoint        string    `json:"endpoint"`
-			Expiration      time.Time `json:"expiration"`
-			Key             string    `json:"key"`
-			SecurityToken   string    `json:"security_token"`
-		} `json:"params"`
-		Provider string `json:"provider"`
+		Kind     string   `json:"kind"`
+		Params   S3Params `json:"params"`
+		Provider string   `json:"provider"`
 	} `json:"resumable"`
 
 	File File `json:"file"`
+}
+
+type S3Params struct {
+	AccessKeyID     string    `json:"access_key_id"`
+	AccessKeySecret string    `json:"access_key_secret"`
+	Bucket          string    `json:"bucket"`
+	Endpoint        string    `json:"endpoint"`
+	Expiration      time.Time `json:"expiration"`
+	Key             string    `json:"key"`
+	SecurityToken   string    `json:"security_token"`
 }
 
 // 添加离线下载响应


### PR DESCRIPTION
### 改动
- 修改了上传时的配置项，现在使用 `webdav` 可正常上传

### 部分已知问题
- 上传时如果遇到 `Method Not Allowed: 405 Method Not Allowed`错误
> 1. 检查 配置文件中的 `temp_dir` 所设置的目录是否存在——默认 为 `data`目录中的 `temp`目录
> 2. 检查是否 触发了 `PikPak`上传限制，非会员一天只能上传一次