### PR TITLE
chore(local): decrease mass ffmpeg logs

### DIFF
--- a/drivers/local/util.go
+++ b/drivers/local/util.go
@@ -36,12 +36,12 @@ func isSymlinkDir(f fs.FileInfo, path string) bool {
 
 func GetSnapshot(videoPath string, frameNum int) (imgData *bytes.Buffer, err error) {
 	srcBuf := bytes.NewBuffer(nil)
-	err = ffmpeg.Input(videoPath).Filter("select", ffmpeg.Args{fmt.Sprintf("gte(n,%d)", frameNum)}).
+	stream := ffmpeg.Input(videoPath).
+		Filter("select", ffmpeg.Args{fmt.Sprintf("gte(n,%d)", frameNum)}).
 		Output("pipe:", ffmpeg.KwArgs{"vframes": 1, "format": "image2", "vcodec": "mjpeg"}).
-		WithOutput(srcBuf, os.Stdout).
-		Run()
-
-	if err != nil {
+		GlobalArgs("-loglevel", "error").Silent(true).
+		WithOutput(srcBuf, os.Stdout)
+	if err = stream.Run(); err != nil {
 		return nil, err
 	}
 	return srcBuf, nil


### PR DESCRIPTION
Currently, ffmpeg outputs about 150 lines of logs for each thumbnail generation action. This PR makes ffmpeg only output logs at the error level and above.

Test Image: `mmx233/alist:v3.36.0-beta2-ffmpeg`