### PR TITLE
fix: disallow users with 2FA enabled to access WebDAV

### DIFF
--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -56,6 +56,10 @@ func (u *User) IsAdmin() bool {
 	return u.Role == ADMIN
 }
 
+func (u *User) IsOtpEnabled() bool {
+	return u.OtpSecret != ""
+}
+
 func (u *User) ValidateRawPassword(password string) error {
 	return u.ValidatePwdStaticHash(StaticHash(password))
 }

--- a/server/webdav.go
+++ b/server/webdav.go
@@ -79,7 +79,7 @@ func WebDAVAuth(c *gin.Context) {
 		return
 	}
 	user, err := op.GetUserByName(username)
-	if err != nil || user.ValidateRawPassword(password) != nil {
+	if err != nil || user.IsOtpEnabled() || user.ValidateRawPassword(password) != nil {
 		if c.Request.Method == "OPTIONS" {
 			c.Set("user", guest)
 			c.Next()


### PR DESCRIPTION
WebDAV server doesn't validate 2FA. This makes 2FA useless to some extent. I think users with 2FA enabled shouldn't access webdav using only password. Although this can be manually solved by changing user permissions, Alist doesn't support to change permissions of admin.

BREAKING CHANGE: Users with 2FA enabled will not be able to access WebDAV.