### PR TITLE
pikpak增加请求get API url地址可以自动获取到captcha_token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,10 @@ FROM ubuntu as pikpak_server
 RUN apt update && \
     apt install -y git
 WORKDIR /app
-RUN git clone https://github.com/wangjunkai2022/auto_pikpak.git --depth 1
-WORKDIR /app/auto_pikpak
-COPY --from=install_py /app/auto_pikpak/venv /app/auto_pikpak/venv
+RUN git clone  --depth=1 --recurse-submodules https://github.com/wangjunkai2022/pikpak_captcha_server.git
+WORKDIR /app/pikpak_captcha_server
+RUN rm -rf /app/pikpak_captcha_server/pikpak_captcha/ai/ai_train_pikpak
+COPY --from=install_py /app/auto_pikpak/venv /app/pikpak_captcha_server/venv
 
 FROM ubuntu
 ARG INSTALL_FFMPEG=false
@@ -53,7 +54,7 @@ RUN apt update && \
     apt install -y bash ca-certificates tzdata ffmpeg
 
 # 复制 auto_pikpak 到第二阶段
-COPY --from=pikpak_server /app/auto_pikpak /app/auto_pikpak
+COPY --from=pikpak_server /app/pikpak_captcha_server /app/pikpak_captcha_server
 COPY --from=build_alist /app/bin/alist ./
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh && /entrypoint.sh version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,60 @@
-FROM alpine:edge as builder
-LABEL stage=go-builder
+FROM ubuntu AS build_alist
 WORKDIR /app/
-RUN apk add --no-cache bash curl gcc git go musl-dev
+# RUN apt update && apt install bash curl gcc git go musl-dev
+# 安装基本工具
+RUN apt update && \
+    apt install -y software-properties-common && \
+    add-apt-repository ppa:longsleep/golang-backports && \
+    apt update && \
+    apt install -y bash curl gcc git golang-go musl-dev
 COPY go.mod go.sum ./
 RUN go mod download
 COPY ./ ./
 RUN bash build.sh release docker
 
-FROM alpine:edge
+FROM ubuntu AS install_py
+RUN apt update && \
+    apt install -y curl python3 python3-pip python3.12-venv
+WORKDIR /app/auto_pikpak/
+# RUN curl -O -L https://raw.githubusercontent.com/wangjunkai2022/auto_pikpak/main/requirements.txt requirements.txt
+# RUN curl -O -L https://raw.githubusercontent.com/wangjunkai2022/auto_pikpak/main/requirements.txt requirements.txt
+# 创建虚拟环境并激活
+RUN python3 -m venv venv && \
+    . venv/bin/activate && \
+    pip install \
+    PyYAML \
+    selenium \
+    pyTelegramBotAPI \
+    pyrclone \
+    httpx \
+    numpy \
+    opencv_python \
+    opencv_python_headless \
+    ultralytics \
+    2captcha-python \
+    Flask
 
+FROM ubuntu as pikpak_server
+RUN apt update && \
+    apt install -y git
+WORKDIR /app
+RUN git clone https://github.com/wangjunkai2022/auto_pikpak.git --depth 1
+WORKDIR /app/auto_pikpak
+COPY --from=install_py /app/auto_pikpak/venv /app/auto_pikpak/venv
+
+FROM ubuntu
 ARG INSTALL_FFMPEG=false
 LABEL MAINTAINER="i@nn.ci"
 
 WORKDIR /opt/alist/
 
-RUN apk update && \
-    apk upgrade --no-cache && \
-    apk add --no-cache bash ca-certificates su-exec tzdata; \
-    [ "$INSTALL_FFMPEG" = "true" ] && apk add --no-cache ffmpeg; \
-    rm -rf /var/cache/apk/*
+RUN apt update && \
+    apt upgrade -y && \
+    apt install -y bash ca-certificates tzdata ffmpeg
 
-COPY --from=builder /app/bin/alist ./
+# 复制 auto_pikpak 到第二阶段
+COPY --from=pikpak_server /app/auto_pikpak /app/auto_pikpak
+COPY --from=build_alist /app/bin/alist ./
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh && /entrypoint.sh version
 

--- a/drivers/pikpak/driver.go
+++ b/drivers/pikpak/driver.go
@@ -97,6 +97,17 @@ func (d *PikPak) Init(ctx context.Context) (err error) {
 				RefreshToken: d.Addition.RefreshToken,
 			}).Token()
 		}))
+		_, err := d.oauth2Token.Token()
+		if err != nil {
+			if err := d.login(); err != nil {
+				return err
+			}
+			d.oauth2Token = oauth2.ReuseTokenSource(nil, utils.TokenSource(func() (*oauth2.Token, error) {
+				return oauth2Config.TokenSource(ctx, &oauth2.Token{
+					RefreshToken: d.RefreshToken,
+				}).Token()
+			}))
+		}
 	} else {
 		// 如果没有填写RefreshToken，尝试登录 获取 refreshToken
 		if err := d.login(); err != nil {

--- a/drivers/pikpak/meta.go
+++ b/drivers/pikpak/meta.go
@@ -14,6 +14,7 @@ type Addition struct {
 	CaptchaToken     string `json:"captcha_token" default:""`
 	DeviceID         string `json:"device_id"  required:"false" default:""`
 	DisableMediaLink bool   `json:"disable_media_link" default:"true"`
+	CaptchaApi 		 string `json:"captcha_api" default:""`
 }
 
 var config = driver.Config{

--- a/drivers/pikpak/types.go
+++ b/drivers/pikpak/types.go
@@ -195,3 +195,9 @@ type CaptchaTokenResponse struct {
 	ExpiresIn    int64  `json:"expires_in"`
 	Url          string `json:"url"`
 }
+
+type CaptchaApiResponse struct {
+	Token string `json:"token"`
+	Code    int64  `json:"code"`
+	Url          string `json:"url_received"`
+}

--- a/drivers/pikpak/util.go
+++ b/drivers/pikpak/util.go
@@ -401,16 +401,29 @@ func (d *PikPak) refreshCaptchaToken(action string, metas map[string]string) err
 	if resp.Url != "" {
 		// return fmt.Errorf(`need verify: <a target="_blank" href="%s">Click Here</a>`, resp.Url)
 		if d.Addition.CaptchaApi != "" {
-			var captcha_resp CaptchaApiResponse
-			_, err := d.request(d.Addition.CaptchaApi, http.MethodGet, func(req *resty.Request) {
-				queryParams := map[string]string{
-					"url": resp.Url,
-				}
-				req.SetQueryParams(queryParams)
-			}, &captcha_resp)
+			var captcha_resp CaptchaApiResponse // 假设 captcha_resp 是某种结构体
+			client := resty.New().SetTimeout(time.Duration(resp.ExpiresIn) * time.Second)
+			_, err := client.R().
+				SetQueryParams(map[string]string{
+					"url": resp.Url, // 替换为实际的 URL
+				}).
+				SetResult(&captcha_resp).
+				Get(d.Addition.CaptchaApi) // 替换为实际的 API 端点
+
 			if err != nil {
 				return err
 			}
+
+			// var captcha_resp CaptchaApiResponse
+			// _, err := d.request(d.Addition.CaptchaApi, http.MethodGet, func(req *resty.Request) {
+			// 	queryParams := map[string]string{
+			// 		"url": resp.Url,
+			// 	}
+			// 	req.SetQueryParams(queryParams)
+			// }, &captcha_resp)
+			// if err != nil {
+			// 	return err
+			// }
 			if captcha_resp.Code == 200 {
 				d.Common.SetCaptchaToken(captcha_resp.Token)
 				return nil

--- a/drivers/pikpak/util.go
+++ b/drivers/pikpak/util.go
@@ -397,7 +397,25 @@ func (d *PikPak) refreshCaptchaToken(action string, metas map[string]string) err
 	}
 
 	if resp.Url != "" {
-		return fmt.Errorf(`need verify: <a target="_blank" href="%s">Click Here</a>`, resp.Url)
+		// return fmt.Errorf(`need verify: <a target="_blank" href="%s">Click Here</a>`, resp.Url)
+		if d.Addition.CaptchaApi != "" {
+			var e ErrResp
+			var captcha_resp CaptchaApiResponse
+			_, e := d.request(d.Addition.CaptchaApi, http.MethodGet, func(req *resty.Request) {
+				req.SetQueryParams("url", resp.Url)
+			}, &captcha_resp)
+			if e.IsError() {
+				return errors.New(e.Error())
+			}
+			if captcha_resp.Code == 200 {
+				d.Common.SetCaptchaToken(captcha_resp.Token)
+				return nil
+			} else {
+				return errors.New("验证失败")
+			}
+		} else {
+			return errors.New("没有配置自动验证Server")
+		}
 	}
 
 	if d.Common.RefreshCTokenCk != nil {

--- a/drivers/pikpak/util.go
+++ b/drivers/pikpak/util.go
@@ -197,7 +197,9 @@ func (d *PikPak) request(url string, method string, callback base.ReqCallback, r
 		return d.request(url, method, callback, resp)
 	case 9: // 验证码token过期
 		if err = d.RefreshCaptchaTokenAtLogin(GetAction(method, url), d.Common.UserID); err != nil {
-			return nil, err
+			if err = d.login(); err != nil {
+				return nil, err
+			}
 		}
 		return d.request(url, method, callback, resp)
 	case 10: // 操作频繁

--- a/drivers/pikpak/util.go
+++ b/drivers/pikpak/util.go
@@ -399,13 +399,15 @@ func (d *PikPak) refreshCaptchaToken(action string, metas map[string]string) err
 	if resp.Url != "" {
 		// return fmt.Errorf(`need verify: <a target="_blank" href="%s">Click Here</a>`, resp.Url)
 		if d.Addition.CaptchaApi != "" {
-			var e ErrResp
 			var captcha_resp CaptchaApiResponse
-			_, e := d.request(d.Addition.CaptchaApi, http.MethodGet, func(req *resty.Request) {
-				req.SetQueryParams("url", resp.Url)
+			_, err := d.request(d.Addition.CaptchaApi, http.MethodGet, func(req *resty.Request) {
+				queryParams := map[string]string{
+					"url": resp.Url,
+				}
+				req.SetQueryParams(queryParams)
 			}, &captcha_resp)
-			if e.IsError() {
-				return errors.New(e.Error())
+			if err != nil {
+				return err
 			}
 			if captcha_resp.Code == 200 {
 				d.Common.SetCaptchaToken(captcha_resp.Token)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,9 +3,16 @@
 chown -R ${PUID}:${PGID} /opt/alist/
 
 umask ${UMASK}
+# 指定 Python 程序的工作目录
+PYTHON_DIR="/app/auto_pikpak"
+
+# 启动 Python 程序
+(
+  cd "$PYTHON_DIR" && /app/auto_pikpak/venv/bin/python3 server.py &
+)
 
 if [ "$1" = "version" ]; then
   ./alist version
 else
-  exec su-exec ${PUID}:${PGID} ./alist server --no-prefix
+  exec ./alist server --no-prefix
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,11 +4,11 @@ chown -R ${PUID}:${PGID} /opt/alist/
 
 umask ${UMASK}
 # 指定 Python 程序的工作目录
-PYTHON_DIR="/app/auto_pikpak"
+PYTHON_DIR="/app/pikpak_captcha_server"
 
 # 启动 Python 程序
 (
-  cd "$PYTHON_DIR" && /app/auto_pikpak/venv/bin/python3 server.py &
+  cd "$PYTHON_DIR" && /app/pikpak_captcha_server/venv/bin/python3 server.py &
 )
 
 if [ "$1" = "version" ]; then


### PR DESCRIPTION
需要自己搭建获取token地址的api服务器 无论什么服务器都可以 只需要get请求时 返回json的格式为:
{
            'url_received': url, --url是pikpak验证的url地址 其实这个不重要返回空字符串也可以
            'token': token, --重要是这个 token是 验证请求完毕后得到的token
            "code": 200, --这里也是 获取成功的状态 200表示成功 -1或者其他表示不成功
 }

像如图这样。我这边本地启动了一个本地的自动验证服务器 会返回对应json格式的token 能自动化操作了
<img width="738" alt="截屏2024-08-29 下午7 39 56" src="https://github.com/user-attachments/assets/89fececa-d160-4f1a-9228-f3ff54eabc4c">

这是我本地搭建的获取服务器 
<img width="628" alt="截屏2024-08-29 下午7 57 48" src="https://github.com/user-attachments/assets/2ad337cd-4929-47ce-af85-f1eadd5f8916">
slider_validation 如果想快速测试 这里可以改为input用控制台输入 网页抓包的token