### PR TITLE
Fix local proxy

### DIFF
--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -102,7 +102,13 @@ func initURL() {
 }
 
 func CleanTempDir() {
-	if err := os.RemoveAll(conf.Conf.TempDir); err != nil {
-		log.Errorln("failed delete temp file: ", err)
+	files, err := os.ReadDir(conf.Conf.TempDir)
+	if err != nil {
+		log.Errorln("failed list temp file: ", err)
+	}
+	for _, file := range files {
+		if err := os.RemoveAll(filepath.Join(conf.Conf.TempDir, file.Name())); err != nil {
+			log.Errorln("failed delete temp file: ", err)
+		}
 	}
 }

--- a/internal/op/fs.go
+++ b/internal/op/fs.go
@@ -267,6 +267,12 @@ func Link(ctx context.Context, storage driver.Driver, path string, args model.Li
 		}
 		return link, nil
 	}
+
+	if storage.Config().OnlyLocal {
+		link, err := fn()
+		return link, file, err
+	}
+
 	link, err, _ := linkG.Do(key, fn)
 	return link, file, err
 }


### PR DESCRIPTION
fix: #7112 #7030
问题： 本地走代理时使用io.ReadSeek接口，共用一个link导致数据污染

考虑到代理时会自动调用io.Close接口，所以不使用io.ReadAt修复, 代价是可能会创建大量文件句柄。
#7030 中的网盘走代理时文件损坏无法复现，可能是 #7003 完成修复