### PR TITLE
fix(google_photo) fix issue copy videos from google photo

### DIFF
--- a/drivers/google_photo/driver.go
+++ b/drivers/google_photo/driver.go
@@ -58,33 +58,9 @@ func (d *GooglePhoto) Link(ctx context.Context, file model.Obj, args model.LinkA
 			URL: f.BaseURL + "=d",
 		}, nil
 	} else if strings.Contains(f.MimeType, "video/") {
-		var width, height int
-
-		fmt.Sscanf(f.MediaMetadata.Width, "%d", &width)
-		fmt.Sscanf(f.MediaMetadata.Height, "%d", &height)
-
-		switch {
-		// 1080P
-		case width == 1920 && height == 1080:
-			return &model.Link{
-				URL: f.BaseURL + "=m37",
-			}, nil
-		// 720P
-		case width == 1280 && height == 720:
-			return &model.Link{
-				URL: f.BaseURL + "=m22",
-			}, nil
-		// 360P
-		case width == 640 && height == 360:
-			return &model.Link{
-				URL: f.BaseURL + "=m18",
-			}, nil
-		default:
-			return &model.Link{
-				URL: f.BaseURL + "=dv",
-			}, nil
-		}
-
+		return &model.Link{
+			URL: f.BaseURL + "=dv",
+		}, nil
 	}
 	return &model.Link{}, nil
 }


### PR DESCRIPTION
#7158 During copy from google photo to aliyun, it failed consistently with 404 when copying mp4 file with =m37.

Change =m37 to =dv will fix the issue