### PR TITLE
fix(lanzou): missing parameter (close #7210)

### DIFF
--- a/drivers/lanzou/help.go
+++ b/drivers/lanzou/help.go
@@ -120,9 +120,9 @@ var findKVReg = regexp.MustCompile(`'(.+?)':('?([^' },]*)'?)`) // 拆分kv
 func findJSVarFunc(key, data string) string {
 	var values []string
 	if key != "sasign" {
-		values = regexp.MustCompile(`var ` + key + ` = '(.+?)';`).FindStringSubmatch(data)
+		values = regexp.MustCompile(`var ` + key + `\s*=\s*['"]?(.+?)['"]?;`).FindStringSubmatch(data)
 	} else {
-		matches := regexp.MustCompile(`var `+key+` = '(.+?)';`).FindAllStringSubmatch(data, -1)
+		matches := regexp.MustCompile(`var `+key+`\s*=\s*['"]?(.+?)['"]?;`).FindAllStringSubmatch(data, -1)
 		if len(matches) == 3 {
 			values = matches[1]
 		} else {

--- a/drivers/lanzou/util.go
+++ b/drivers/lanzou/util.go
@@ -264,6 +264,9 @@ var findSubFolderReg = regexp.MustCompile(`(?i)(?:folderlink|mbxfolder).+href="/
 // 获取下载页面链接
 var findDownPageParamReg = regexp.MustCompile(`<iframe.*?src="(.+?)"`)
 
+// 获取文件ID
+var findFileIDReg = regexp.MustCompile(`'/ajaxm\.php\?file=(\d+)'`)
+
 // 获取分享链接主界面
 func (d *LanZou) getShareUrlHtml(shareID string) (string, error) {
 	var vs string
@@ -356,8 +359,16 @@ func (d *LanZou) getFilesByShareUrl(shareID, pwd string, sharePageData string) (
 			return nil, err
 		}
 		param["p"] = pwd
+
+		fileIDs := findFileIDReg.FindStringSubmatch(sharePageData)
+		var fileID string
+		if len(fileIDs) > 1 {
+			fileID = fileIDs[1]
+		} else {
+			return nil, fmt.Errorf("not find file id")
+		}
 		var resp FileShareInfoAndUrlResp[string]
-		_, err = d.post(d.ShareUrl+"/ajaxm.php", func(req *resty.Request) { req.SetFormData(param) }, &resp)
+		_, err = d.post(d.ShareUrl+"/ajaxm.php?file="+fileID, func(req *resty.Request) { req.SetFormData(param) }, &resp)
 		if err != nil {
 			return nil, err
 		}
@@ -381,8 +392,15 @@ func (d *LanZou) getFilesByShareUrl(shareID, pwd string, sharePageData string) (
 			return nil, err
 		}
 
+		fileIDs := findFileIDReg.FindStringSubmatch(nextPageData)
+		var fileID string
+		if len(fileIDs) > 1 {
+			fileID = fileIDs[1]
+		} else {
+			return nil, fmt.Errorf("not find file id")
+		}
 		var resp FileShareInfoAndUrlResp[int]
-		_, err = d.post(d.ShareUrl+"/ajaxm.php", func(req *resty.Request) { req.SetFormData(param) }, &resp)
+		_, err = d.post(d.ShareUrl+"/ajaxm.php?file="+fileID, func(req *resty.Request) { req.SetFormData(param) }, &resp)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
修改 JS 变量查找函数，增加 ajaxm.php 文件 ID 参数，修复因参数缺失导致获取地址错误的问题：

![](https://github.com/user-attachments/assets/e311c399-823b-40b9-966c-0a97d3b83eb6)
