### PR TITLE
docs: provide K8s deploy

### DIFF
--- a/helm/alist/Chart.yaml
+++ b/helm/alist/Chart.yaml
@@ -1,0 +1,10 @@
+name: alist
+description: A file list program that supports multiple storages, powered by Gin and Solidjs.
+version: v3.45.0
+apiVersion: v1
+keywords:
+- alist
+sources:
+- https://github.com/AlistGo/alist
+home: https://alistgo.com
+icon: https://cdn.jsdelivr.net/gh/alist-org/logo@main/logo.svg

--- a/helm/alist/README.md
+++ b/helm/alist/README.md
@@ -1,0 +1,59 @@
+# Alist Helm Chart
+
+A file list program that supports multiple storages, powered by Gin and Solidjs.
+
+## Introduction
+
+This chart bootstraps alist on [Kubernetes](http://kubernetes.io) using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes cluster 1.20+
+- Helm v3.2.0+
+
+## Configure Alist Helm repo
+
+No Helm repository has been provided. Please `git clone` the code project, and install it manually in the `helm` directory.
+
+```bash
+git clone https://github.com/AlistGo/alist.git
+
+cd alist/helm
+```
+
+### Installing the Chart
+
+Create the alist namespace.
+
+```bash
+kubectl create namespace alist
+```
+
+Install the helm chart into the alist namespace.
+
+```bash
+helm install alist . --namespace alist
+```
+
+### Values reference
+
+The default values.yaml should be suitable for most basic deployments.
+
+| Parameter                  | Description                                                  | Default                         |
+|----------------------------|--------------------------------------------------------------|---------------------------------|
+| `image.registry`           | Imag registry                                                | `docker.io`                     |
+| `image.repository`         | Image name                                                   | `xhofe/alist`                   |
+| `image.tag`                | Image tag                                                    | `latest`                        |
+| `image.pullPolicy`         | Image pull policy                                            | `IfNotPresent`                  |
+| `replicaCount`             | Number of scanner adapter Pods to run                        | `1`                             |
+| `persistence.storageClass` | Specify the storageClass used to provision the volume        |                                 |
+| `persistence.accessMode`   | The access mode of the volume                                | `ReadWriteOnce`                 |
+| `persistence.size`         | The size of the volume                                       | `5Gi`                           |
+| `service.type`             | Kubernetes service type                                      | `ClusterIP`                     |
+| `service.loadBalancerIP`   | Kubernetes service loadBalancerIP                            |                                 |
+| `service.http.port`        | Kubernetes service http port                                 | `5244`                          |
+| `service.http.targetPort`  | Kubernetes service http targetPort                           | `5244`                          |
+| `service.http.nodePort`    | Kubernetes service http nodePort                             | `35244`                         |
+| `service.https.port`       | Kubernetes service https port                                | `5245`                          |
+| `service.https.targetPort` | Kubernetes service https targetPort                          | `5245`                          |
+| `service.https.nodePort`   | Kubernetes service https nodePort                            | `35245`                         |

--- a/helm/alist/templates/_helpers.tpl
+++ b/helm/alist/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "alist.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "alist.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "alist.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/alist/templates/alist-deployment.yaml
+++ b/helm/alist/templates/alist-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "alist.name" . }}
+    chart: {{ template "alist.chart" . }}
+    release: {{ .Release.Name }}
+  name: {{ template "alist.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "alist.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "alist.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - env:
+        - name: PGID
+          value: "0"
+        - name: PUID
+          value: "0"
+        - name: TZ
+          value: UTC
+        - name: UMASK
+          value: "022"
+        name: {{ .Chart.Name }}
+        image: "{{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.http.port }}
+          protocol: TCP
+        - containerPort: {{ .Values.service.https.port }}
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /opt/alist/data
+          name: alist-data
+      restartPolicy: Always
+      enableServiceLinks: false
+      volumes:
+      - name: alist-data
+        persistentVolumeClaim:
+          claimName: {{ template "alist.fullname" . }}

--- a/helm/alist/templates/alist-persistentvolumeclaim.yaml
+++ b/helm/alist/templates/alist-persistentvolumeclaim.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "alist.fullname" . }}
+  labels:
+    app: {{ template "alist.name" . }}
+    chart: {{ template "alist.chart" . }}
+    release: {{ .Release.Name }}
+spec:
+  accessModes:
+  - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+  {{- end }}
+  {{- end }}

--- a/helm/alist/templates/alist-service.yaml
+++ b/helm/alist/templates/alist-service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "alist.fullname" . }}
+spec:
+  type: {{ .Values.service.type | default "ClusterIP" }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ default "" .Values.service.loadBalancerIP | quote }}
+  {{- end }}
+  ports:
+  - name: http
+    protocol: TCP
+    port: {{ .Values.service.http.port }}
+    targetPort: {{ .Values.service.http.targetPort }}
+    {{- if (and (eq .Values.service.type "NodePort") ( .Values.service.http.nodePort)) }}
+    nodePort: {{ .Values.service.http.nodePort }}
+    {{- end }}
+  - name: https
+    protocol: TCP
+    port: {{ .Values.service.https.port }}
+    targetPort: {{ .Values.service.https.targetPort }}
+    {{- if (and (eq .Values.service.type "NodePort") ( .Values.service.https.nodePort)) }}
+    nodePort: {{ .Values.service.https.nodePort }}
+    {{- end }}
+  selector:
+    app: {{ template "alist.name" . }}
+    release: {{ .Release.Name }}

--- a/helm/alist/values.yaml
+++ b/helm/alist/values.yaml
@@ -1,0 +1,28 @@
+nameOverride: ""
+
+fullnameOverride: ""
+
+image:
+  registry: docker.io
+  repository:  xhofe/alist
+  tag: latest
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+persistence:
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 5Gi
+
+service:
+  type: ClusterIP
+  loadBalancerIP: ~
+  http:
+    port: 5244
+    targetPort: 5244
+    nodePort: 35244
+  https:
+    port: 5245
+    targetPort: 5245
+    nodePort: 35245


### PR DESCRIPTION
Alist 也需要在云计算领域推广，毕竟 K8s 已经相当流行了。

提供在 K8s 集群中安装 alist 的方式。将 Helm Chart 包文件维护在项目根路径的 helm 目录下。

> 后续建议官方发布一个 Alist 的 Helm Chart 仓库地址，用户就可以直接使用 helm 命令拉取，而不用从源码仓库中找部署清单了。