### PR TITLE
fix(drivers): add session renewal cron for MediaFire driver

### DIFF
--- a/drivers/mediafire/driver.go
+++ b/drivers/mediafire/driver.go
@@ -11,6 +11,7 @@ D@' 3z K!7 - The King Of Cracking
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"os"
 	"time"
@@ -19,12 +20,14 @@ import (
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/pkg/cron"
 	"github.com/alist-org/alist/v3/pkg/utils"
 )
 
 type Mediafire struct {
 	model.Storage
 	Addition
+	cron *cron.Cron
 
 	actionToken string
 
@@ -57,12 +60,15 @@ func (d *Mediafire) Init(ctx context.Context) error {
 
 	if _, err := d.getSessionToken(ctx); err != nil {
 
-		//fmt.Printf("Init :: Obtain Session Token \n\n")
+		d.renewToken(ctx)
 
-		if err := d.renewToken(ctx); err != nil {
+		num := rand.Intn(4) + 6
 
-			//fmt.Printf("Init :: Renew Session Token \n\n")
-		}
+		d.cron = cron.NewCron(time.Minute * time.Duration(num))
+		d.cron.Do(func() {
+			d.renewToken(ctx)
+		})
+
 	}
 
 	return nil

--- a/drivers/mediafire/util.go
+++ b/drivers/mediafire/util.go
@@ -106,6 +106,9 @@ func (d *Mediafire) getSessionToken(ctx context.Context) (string, error) {
 	}
 
 	d.SessionToken = tokenResp.Response.SessionToken
+
+	//fmt.Printf("Init :: Obtain Session Token %v", d.SessionToken)
+
 	op.MustSaveDriverStorage(d)
 
 	return d.SessionToken, nil
@@ -131,6 +134,9 @@ func (d *Mediafire) renewToken(_ context.Context) error {
 	}
 
 	d.SessionToken = resp.Response.SessionToken
+
+	//fmt.Printf("Init :: Renew Session Token: %s", resp.Response.Result)
+
 	op.MustSaveDriverStorage(d)
 
 	return nil


### PR DESCRIPTION
- Implement automatic session token renewal every 6-9 minutes
- Add validation for required SessionToken and Cookie fields in Init
- Handle session expiration by calling renewToken on validation failure
- Prevent storage failures due to MediaFire session timeouts

Fixes session closure issues that occur after server restarts or extended periods

NOTE: This issue happens due to MediaFire does not provide API_KEY required for App, so is not possible to get full API support anymore. Anyway, MediaFire driver is here :)