### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/auto_lang.yml
+++ b/.github/workflows/auto_lang.yml
@@ -25,17 +25,17 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout alist
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: alist
 
       - name: Checkout alist-web
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'alist-org/alist-web'
           ref: main

--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -74,12 +74,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.22'
 
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: AlistGo/desktop-release
           ref: main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,13 +30,13 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: benjlevesque/short-sha@v3.0
         id: short-sha
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.22'
 
@@ -57,7 +57,7 @@ jobs:
             github.com/alist-org/alist/v3/internal/conf.WebVersion=dev
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: alist_${{ env.SHA }}_${{ matrix.target }}
           path: build/*

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,12 @@ jobs:
           prerelease: true
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: AlistGo/desktop-release
           ref: main

--- a/.github/workflows/release_android.yml
+++ b/.github/workflows/release_android.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -36,15 +36,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: 'stable'
 
       - name: Cache Musl
         id: cache-musl
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build/musl-libs
           key: docker-musl-libs-v2
@@ -62,7 +62,7 @@ jobs:
         run: bash build.sh release docker-multiplatform
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.ARTIFACT_NAME }}
           overwrite: true
@@ -95,8 +95,8 @@ jobs:
             tag_favor: "suffix=-aio,onlatest=true"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+        uses: actions/checkout@v6
+      - uses: actions/download-artifact@v7
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: 'build/'

--- a/.github/workflows/release_freebsd.yml
+++ b/.github/workflows/release_freebsd.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release_linux_musl.yml
+++ b/.github/workflows/release_linux_musl.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release_linux_musl_arm.yml
+++ b/.github/workflows/release_linux_musl_arm.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/release_docker.yml`
- Updated `actions/cache` from `v4` to `v5` in `.github/workflows/release_docker.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release_docker.yml`
- Updated `actions/setup-go` from `v5` to `v6` in `.github/workflows/release_android.yml`
- Updated `actions/setup-go` from `v5` to `v6` in `.github/workflows/release_linux_musl.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release_linux_musl_arm.yml`
- Updated `actions/setup-go` from `v5` to `v6` in `.github/workflows/auto_lang.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release_android.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release_linux_musl.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/auto_lang.yml`
- Updated `actions/setup-go` from `v5` to `v6` in `.github/workflows/release_linux_musl_arm.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/beta_release.yml`
- Updated `actions/setup-go` from `v5` to `v6` in `.github/workflows/beta_release.yml`
- Updated `actions/setup-go` from `v5` to `v6` in `.github/workflows/release_freebsd.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release_freebsd.yml`
- Updated `actions/setup-go` from `v5` to `v6` in `.github/workflows/release.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/changelog.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/build.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/release_docker.yml`
- Updated `actions/setup-go` from `v5` to `v6` in `.github/workflows/release_docker.yml`
- Updated `actions/setup-go` from `v5` to `v6` in `.github/workflows/build.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/build.yml`
