### PR TITLE
fix: If the file name contains "#", the selection will not be displ...

### DIFF
--- a/server/middlewares/down.go
+++ b/server/middlewares/down.go
@@ -1,6 +1,7 @@
 package middlewares
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/alist-org/alist/v3/internal/conf"
@@ -41,9 +42,8 @@ func Down(verifyFunc func(string, string) error) func(c *gin.Context) {
 	}
 }
 
-// TODO: implement
-// path maybe contains # ? etc.
 func parsePath(path string) string {
+	path, _ = url.PathUnescape(path)
 	return utils.FixAndCleanPath(path)
 }
 


### PR DESCRIPTION
## Summary

修复文件名包含 "#" 字符时无法正常显示的问题。通过添加 URL 路径解码，确保特殊字符被正确处理。

## Issue

Fixes #9361

## Changes

- 在 `parsePath` 函数中添加 `url.PathUnescape` 调用，解码 URL 编码的文件路径
- 移除过时的 TODO 注释（功能已实现）

## Testing

- 验证包含 "#" 字符的文件名现在可以正常选择和下载
- URL 编码的特殊字符（如 %23、%20 等）被正确解码处理