### PR TITLE
feat(local): make thumbnail size configurable via system settings

### DIFF
--- a/drivers/local/driver.go
+++ b/drivers/local/driver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alist-org/alist/v3/internal/driver"
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/op"
 	"github.com/alist-org/alist/v3/internal/sign"
 	"github.com/alist-org/alist/v3/pkg/utils"
 	"github.com/alist-org/alist/v3/server/common"
@@ -31,6 +32,7 @@ type Local struct {
 	model.Storage
 	Addition
 	mkdirPerm int32
+	thumbSize int
 
 	// zero means no limit
 	thumbConcurrency int
@@ -70,6 +72,17 @@ func (d *Local) Init(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+	}
+	d.thumbSize = 144
+	if item, err := op.GetSettingItemByKey(conf.ThumbnailSize); err == nil && item != nil && strings.TrimSpace(item.Value) != "" {
+		v, err := strconv.ParseUint(item.Value, 10, 32)
+		if err != nil {
+			return fmt.Errorf("invalid setting %s value: %s, err: %s", conf.ThumbnailSize, item.Value, err)
+		}
+		if v == 0 {
+			return fmt.Errorf("invalid setting %s value: %s, the value must be a positive integer", conf.ThumbnailSize, item.Value)
+		}
+		d.thumbSize = int(v)
 	}
 	if d.ThumbConcurrency != "" {
 		v, err := strconv.ParseUint(d.ThumbConcurrency, 10, 32)

--- a/drivers/local/util.go
+++ b/drivers/local/util.go
@@ -111,7 +111,7 @@ func readDir(dirname string) ([]fs.FileInfo, error) {
 func (d *Local) getThumb(file model.Obj) (*bytes.Buffer, *string, error) {
 	fullPath := file.GetPath()
 	thumbPrefix := "alist_thumb_"
-	thumbName := thumbPrefix + utils.GetMD5EncodeStr(fullPath) + ".png"
+	thumbName := thumbPrefix + utils.GetMD5EncodeStr(fmt.Sprintf("%s:%d", fullPath, d.thumbSize)) + ".png"
 	if d.ThumbCacheFolder != "" {
 		// skip if the file is a thumbnail
 		if strings.HasPrefix(file.GetName(), thumbPrefix) {
@@ -142,7 +142,7 @@ func (d *Local) getThumb(file model.Obj) (*bytes.Buffer, *string, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	thumbImg := imaging.Resize(image, 144, 0, imaging.Lanczos)
+	thumbImg := imaging.Resize(image, d.thumbSize, 0, imaging.Lanczos)
 	var buf bytes.Buffer
 	err = imaging.Encode(&buf, thumbImg, imaging.PNG)
 	if err != nil {

--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -146,6 +146,7 @@ func InitialSettings() []model.SettingItem {
 		{Key: "audio_cover", Value: "https://jsd.nn.ci/gh/alist-org/logo@main/logo.svg", Type: conf.TypeString, Group: model.PREVIEW},
 		{Key: conf.AudioAutoplay, Value: "true", Type: conf.TypeBool, Group: model.PREVIEW},
 		{Key: conf.VideoAutoplay, Value: "true", Type: conf.TypeBool, Group: model.PREVIEW},
+		{Key: conf.ThumbnailSize, Value: "144", Type: conf.TypeNumber, Group: model.PREVIEW, Help: "Thumbnail width in pixels. Height is scaled proportionally."},
 		{Key: conf.PreviewArchivesByDefault, Value: "true", Type: conf.TypeBool, Group: model.PREVIEW},
 		{Key: conf.ReadMeAutoRender, Value: "true", Type: conf.TypeBool, Group: model.PREVIEW},
 		{Key: conf.FilterReadMeScripts, Value: "true", Type: conf.TypeBool, Group: model.PREVIEW},

--- a/internal/conf/const.go
+++ b/internal/conf/const.go
@@ -33,6 +33,7 @@ const (
 	ProxyIgnoreHeaders       = "proxy_ignore_headers"
 	AudioAutoplay            = "audio_autoplay"
 	VideoAutoplay            = "video_autoplay"
+	ThumbnailSize            = "thumbnail_size"
 	PreviewArchivesByDefault = "preview_archives_by_default"
 	ReadMeAutoRender         = "readme_autorender"
 	FilterReadMeScripts      = "filter_readme_scripts"


### PR DESCRIPTION
## Summary
- add `thumbnail_size` as a system setting in `PREVIEW` group (default: `144`)
- make Local driver read `thumbnail_size` from system settings at init
- validate setting value must be a positive integer
- use configured size when generating thumbnails
- include thumbnail size in cache key to avoid stale cache reuse after size changes

## Why
Thumbnail generation width is currently hardcoded to `144`, which cannot be tuned for different usage scenarios. This PR makes it configurable from system settings while preserving the default behavior.

## Notes
- default remains `144` for backward compatibility
- only Local driver thumbnail generation is affected
