### PR TITLE
fix(rename): block rename for password-protected paths

### DIFF
--- a/server/handles/fsbatch.go
+++ b/server/handles/fsbatch.go
@@ -195,6 +195,9 @@ func FsBatchRename(c *gin.Context) {
 			common.ErrorResp(c, err, 400)
 			return
 		}
+		if !canRenamePath(c, filePath) {
+			return
+		}
 		if err := fs.Rename(c, filePath, renameObject.NewName); err != nil {
 			common.ErrorResp(c, err, 500)
 			return
@@ -259,6 +262,9 @@ func FsRegexRename(c *gin.Context) {
 			filePath, err := utils.JoinUnderBase(reqPath, file.GetName())
 			if err != nil {
 				common.ErrorResp(c, err, 500)
+				return
+			}
+			if !canRenamePath(c, filePath) {
 				return
 			}
 			newFileName := srcRegexp.ReplaceAllString(file.GetName(), req.NewNameRegex)

--- a/server/handles/fsmanage.go
+++ b/server/handles/fsmanage.go
@@ -2,9 +2,10 @@ package handles
 
 import (
 	"fmt"
-	"github.com/alist-org/alist/v3/internal/task"
 	"io"
 	stdpath "path"
+
+	"github.com/alist-org/alist/v3/internal/task"
 
 	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/fs"
@@ -213,6 +214,22 @@ type RenameReq struct {
 	Overwrite bool   `json:"overwrite"`
 }
 
+func canRenamePath(c *gin.Context, reqPath string) bool {
+	meta, err := op.GetNearestMeta(reqPath)
+	if err != nil {
+		if !errors.Is(errors.Cause(err), errs.MetaNotFound) {
+			common.ErrorResp(c, err, 500, true)
+			return false
+		}
+		return true
+	}
+	if meta != nil && meta.Password != "" && common.IsApply(meta.Path, reqPath, meta.PSub) {
+		common.ErrorStrResp(c, "Path is password-protected and cannot be renamed.", 403)
+		return false
+	}
+	return true
+}
+
 func FsRename(c *gin.Context) {
 	var req RenameReq
 	if err := c.ShouldBind(&req); err != nil {
@@ -227,6 +244,9 @@ func FsRename(c *gin.Context) {
 	}
 	if !common.CheckPathLimitWithRoles(user, reqPath) {
 		common.ErrorResp(c, errs.PermissionDenied, 403)
+		return
+	}
+	if !canRenamePath(c, reqPath) {
 		return
 	}
 	perm := common.MergeRolePermissions(user, reqPath)


### PR DESCRIPTION
## Summary
- block single-file rename when target path is protected by meta password
- block batch/regex rename for each file when target path is protected by meta password
- return clear error message: "Path is password-protected and cannot be renamed."

## Behavior
When a path matches a meta rule with a non-empty password (`p_sub` respected), rename operations are rejected with HTTP 403.

## Scope
- `server/handles/fsmanage.go`
- `server/handles/fsbatch.go`
