### PR TITLE
fix: reduce WebDAV logging for NotFoundError

### DIFF
--- a/server/webdav.go
+++ b/server/webdav.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/alist-org/alist/v3/internal/errs"
 	"github.com/alist-org/alist/v3/internal/stream"
 	"github.com/alist-org/alist/v3/server/middlewares"
 
@@ -31,6 +32,12 @@ func WebDav(dav *gin.RouterGroup) {
 		Prefix:     path.Join(conf.URL.Path, "/dav"),
 		LockSystem: webdav.NewMemLS(),
 		Logger: func(request *http.Request, err error) {
+			// Skip logging for NotFoundError as it's not a program error
+			// but a normal case when a file doesn't exist
+			if errs.IsNotFoundError(err) {
+				log.Debugf("%s %s %v", request.Method, request.URL.Path, err)
+				return
+			}
 			log.Errorf("%s %s %+v", request.Method, request.URL.Path, err)
 		},
 	}


### PR DESCRIPTION
## Summary

Reduce log noise in WebDAV when a file is not found by logging at DEBUG level instead of ERROR level. When a client attempts to access a non-existent file, this is a normal case and not a program error, so it shouldn't generate ERROR-level logs with full stack traces.

## Changes

- Modified  to check if the error is a  before logging
- If it's a , log at DEBUG level with simplified error message (no stack trace)
- Otherwise, log at ERROR level with full stack trace as before

## Issue

Fixes #9141

## Testing

This change affects only logging behavior:
- Normal errors continue to be logged at ERROR level with full stack traces
- NotFoundError (file not found) is now logged at DEBUG level without stack trace
- No functional changes to WebDAV behavior