### PR TITLE
fix: enable GFM extension for markdown rendering in proxy mode

### DIFF
--- a/server/handles/down.go
+++ b/server/handles/down.go
@@ -18,6 +18,7 @@ import (
 	"github.com/microcosm-cc/bluemonday"
 	log "github.com/sirupsen/logrus"
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
 )
 
 func Down(c *gin.Context) {
@@ -151,7 +152,8 @@ func localProxy(c *gin.Context, link *model.Link, file model.Obj, proxyRange boo
 			}
 
 			var html bytes.Buffer
-			if err = goldmark.Convert(buf.Bytes(), &html); err != nil {
+			md := goldmark.New(goldmark.WithExtensions(extension.GFM))
+			if err = md.Convert(buf.Bytes(), &html); err != nil {
 				err = fmt.Errorf("markdown conversion failed: %w", err)
 			} else {
 				buf.Reset()


### PR DESCRIPTION
## Summary

When `filter_readme_scripts` is enabled, markdown files served through the proxy (`/p/` and `/d/`) are converted to HTML via `goldmark.Convert()`. However, the default goldmark converter does not include GFM extensions, so **tables, strikethrough, autolinks, and task lists are rendered as plain text** instead of proper HTML elements.

For example, a GFM table:
```markdown
| col1 | col2 |
|------|------|
| a    | b    |
```
gets wrapped in `<p>` as plain text instead of generating `<table>` HTML.

This PR adds `extension.GFM` to the goldmark converter. No new dependencies are needed — `goldmark/extension` is part of the `github.com/yuin/goldmark` package already in `go.mod`.

## Changes

- `server/handles/down.go`: Replace `goldmark.Convert()` with a goldmark instance configured with `extension.GFM`

## Test plan

- [ ] Enable `filter_readme_scripts` in settings
- [ ] Create a markdown file with a GFM table and view it through the web UI proxy
- [ ] Verify the table renders as an HTML `<table>` element instead of plain text in `<p>`
- [ ] Verify strikethrough (`~~text~~`) also renders correctly