### PR TITLE
feat(driver): add Darkibox driver

### DIFF
--- a/drivers/all.go
+++ b/drivers/all.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/alist-org/alist/v3/drivers/cloudreve"
 	_ "github.com/alist-org/alist/v3/drivers/cloudreve_v4"
 	_ "github.com/alist-org/alist/v3/drivers/crypt"
+	_ "github.com/alist-org/alist/v3/drivers/darkibox"
 	_ "github.com/alist-org/alist/v3/drivers/doubao"
 	_ "github.com/alist-org/alist/v3/drivers/doubao_new"
 	_ "github.com/alist-org/alist/v3/drivers/doubao_share"

--- a/drivers/darkibox/driver.go
+++ b/drivers/darkibox/driver.go
@@ -1,0 +1,299 @@
+package darkibox
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/alist-org/alist/v3/drivers/base"
+	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/errs"
+	"github.com/alist-org/alist/v3/internal/model"
+	"github.com/alist-org/alist/v3/internal/op"
+)
+
+type Darkibox struct {
+	model.Storage
+	Addition
+}
+
+func (d *Darkibox) Config() driver.Config {
+	return config
+}
+
+func (d *Darkibox) GetAddition() driver.Additional {
+	return &d.Addition
+}
+
+func (d *Darkibox) Init(ctx context.Context) error {
+	if d.APIKey == "" {
+		return fmt.Errorf("API key is required")
+	}
+	if d.RootFolderID == "" {
+		d.RootFolderID = "0"
+	}
+
+	// Verify API key by calling account/info
+	var account accountInfoResult
+	if err := d.callAPI(ctx, "/account/info", nil, &account); err != nil {
+		return fmt.Errorf("failed to verify API key: %w", err)
+	}
+
+	op.MustSaveDriverStorage(d)
+	return nil
+}
+
+func (d *Darkibox) Drop(ctx context.Context) error {
+	return nil
+}
+
+func (d *Darkibox) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
+	folderID := d.RootFolderID
+	if dir.GetID() != "" {
+		folderID = folderIDFromObjID(dir.GetID())
+	}
+
+	var objects []model.Obj
+
+	// List sub-folders via /api/folder/list
+	var folders folderListResult
+	if err := d.callAPI(ctx, "/folder/list", map[string]string{
+		"fld_id": fldIDStr(folderID),
+	}, &folders); err != nil {
+		return nil, fmt.Errorf("list folders failed: %w", err)
+	}
+	for _, f := range folders.Folders {
+		objects = append(objects, &model.Object{
+			ID:       encodeFolderID(f.FldID),
+			Name:     f.Name,
+			IsFolder: true,
+		})
+	}
+
+	// List files via /api/file/list (paginated)
+	page := 1
+	for {
+		var files fileListResult
+		if err := d.callAPI(ctx, "/file/list", map[string]string{
+			"fld_id":   fldIDStr(folderID),
+			"per_page": "200",
+			"page":     strconv.Itoa(page),
+		}, &files); err != nil {
+			return nil, fmt.Errorf("list files failed: %w", err)
+		}
+
+		for _, f := range files.Files {
+			modified := time.Now()
+			if f.Uploaded != "" {
+				if t, err := time.Parse("2006-01-02 15:04:05", f.Uploaded); err == nil {
+					modified = t
+				}
+			}
+			name := f.Name
+			if name == "" {
+				name = f.Title
+			}
+			objects = append(objects, &model.Object{
+				ID:       encodeFileID(f.FileCode),
+				Name:     name,
+				Size:     f.Size,
+				Modified: modified,
+				IsFolder: false,
+			})
+		}
+
+		// Check if there are more pages
+		if len(files.Files) < 200 {
+			break
+		}
+		page++
+	}
+
+	return objects, nil
+}
+
+func (d *Darkibox) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
+	if file.IsDir() {
+		return nil, errs.NotFile
+	}
+
+	fileCode := fileCodeFromObjID(file.GetID())
+	if fileCode == "" {
+		return nil, fmt.Errorf("empty file code")
+	}
+
+	var result directLinkResult
+	if err := d.callAPI(ctx, "/file/direct_link", map[string]string{
+		"file_code": fileCode,
+	}, &result); err != nil {
+		return nil, fmt.Errorf("failed to get direct link: %w", err)
+	}
+
+	// Find the original quality version, fall back to first available
+	var dlURL string
+	for _, v := range result.Versions {
+		if v.Name == "o" {
+			dlURL = v.URL
+			break
+		}
+	}
+	if dlURL == "" && len(result.Versions) > 0 {
+		dlURL = result.Versions[0].URL
+	}
+	if dlURL == "" {
+		return nil, fmt.Errorf("no download URL available for file %s", fileCode)
+	}
+
+	return &model.Link{
+		URL: dlURL,
+	}, nil
+}
+
+func (d *Darkibox) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) (model.Obj, error) {
+	parentID := d.RootFolderID
+	if parentDir.GetID() != "" {
+		parentID = folderIDFromObjID(parentDir.GetID())
+	}
+
+	var result folderCreateResult
+	if err := d.callAPI(ctx, "/folder/create", map[string]string{
+		"name":      dirName,
+		"parent_id": fldIDStr(parentID),
+	}, &result); err != nil {
+		return nil, fmt.Errorf("create folder failed: %w", err)
+	}
+
+	return &model.Object{
+		ID:       encodeFolderID(result.FldID),
+		Name:     dirName,
+		IsFolder: true,
+	}, nil
+}
+
+func (d *Darkibox) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
+	if srcObj.IsDir() {
+		return nil, errs.NotImplement
+	}
+
+	fileCode := fileCodeFromObjID(srcObj.GetID())
+	if fileCode == "" {
+		return nil, fmt.Errorf("empty file code")
+	}
+
+	dstFolderID := d.RootFolderID
+	if dstDir.GetID() != "" {
+		dstFolderID = folderIDFromObjID(dstDir.GetID())
+	}
+
+	if err := d.callAPI(ctx, "/file/move", map[string]string{
+		"file_code": fileCode,
+		"to_folder": fldIDStr(dstFolderID),
+	}, nil); err != nil {
+		return nil, fmt.Errorf("move file failed: %w", err)
+	}
+
+	return &model.Object{
+		ID:       srcObj.GetID(),
+		Name:     srcObj.GetName(),
+		Size:     srcObj.GetSize(),
+		Modified: srcObj.ModTime(),
+		IsFolder: false,
+	}, nil
+}
+
+func (d *Darkibox) Rename(ctx context.Context, srcObj model.Obj, newName string) (model.Obj, error) {
+	return nil, errs.NotImplement
+}
+
+func (d *Darkibox) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
+	return nil, errs.NotImplement
+}
+
+func (d *Darkibox) Remove(ctx context.Context, obj model.Obj) error {
+	if obj.IsDir() {
+		folderID := folderIDFromObjID(obj.GetID())
+		return d.callAPI(ctx, "/folder/delete", map[string]string{
+			"fld_id": folderID,
+		}, nil)
+	}
+
+	fileCode := fileCodeFromObjID(obj.GetID())
+	return d.callAPI(ctx, "/file/delete", map[string]string{
+		"file_code": fileCode,
+	}, nil)
+}
+
+func (d *Darkibox) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
+	folderID := d.RootFolderID
+	if dstDir.GetID() != "" {
+		folderID = folderIDFromObjID(dstDir.GetID())
+	}
+
+	// Step 1: Get the upload server URL
+	var server uploadServerResult
+	if err := d.callAPI(ctx, "/upload/server", nil, &server); err != nil {
+		return nil, fmt.Errorf("get upload server failed: %w", err)
+	}
+	if server.URL == "" {
+		return nil, fmt.Errorf("no upload server URL returned")
+	}
+
+	// Step 2: Upload the file to the upload server
+	reader := driver.NewLimitedUploadStream(ctx, &driver.ReaderUpdatingProgress{
+		Reader:         file,
+		UpdateProgress: up,
+	})
+
+	res, err := base.RestyClient.R().
+		SetContext(ctx).
+		SetMultipartField("file", file.GetName(), "", reader).
+		SetMultipartFormData(map[string]string{
+			"key":    d.APIKey,
+			"fld_id": fldIDStr(folderID),
+		}).
+		Post(server.URL)
+	if err != nil {
+		return nil, fmt.Errorf("upload failed: %w", err)
+	}
+	if res.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("upload failed: http %d", res.StatusCode())
+	}
+
+	// Try to parse upload response to get the file code
+	var uploadResp uploadResult
+	if err := base.RestyClient.JSONUnmarshal(res.Body(), &uploadResp); err == nil && len(uploadResp.Files) > 0 {
+		uf := uploadResp.Files[0]
+		return &model.Object{
+			ID:       encodeFileID(uf.FileCode),
+			Name:     file.GetName(),
+			Size:     file.GetSize(),
+			IsFolder: false,
+		}, nil
+	}
+
+	return &model.Object{
+		Name:     file.GetName(),
+		Size:     file.GetSize(),
+		IsFolder: false,
+	}, nil
+}
+
+func (d *Darkibox) GetArchiveMeta(ctx context.Context, obj model.Obj, args model.ArchiveArgs) (model.ArchiveMeta, error) {
+	return nil, errs.NotImplement
+}
+
+func (d *Darkibox) ListArchive(ctx context.Context, obj model.Obj, args model.ArchiveInnerArgs) ([]model.Obj, error) {
+	return nil, errs.NotImplement
+}
+
+func (d *Darkibox) Extract(ctx context.Context, obj model.Obj, args model.ArchiveInnerArgs) (*model.Link, error) {
+	return nil, errs.NotImplement
+}
+
+func (d *Darkibox) ArchiveDecompress(ctx context.Context, srcObj, dstDir model.Obj, args model.ArchiveDecompressArgs) ([]model.Obj, error) {
+	return nil, errs.NotImplement
+}
+
+var _ driver.Driver = (*Darkibox)(nil)

--- a/drivers/darkibox/meta.go
+++ b/drivers/darkibox/meta.go
@@ -1,0 +1,27 @@
+package darkibox
+
+import (
+	"github.com/alist-org/alist/v3/internal/driver"
+	"github.com/alist-org/alist/v3/internal/op"
+)
+
+type Addition struct {
+	driver.RootID
+	APIKey string `json:"api_key" required:"true" help:"API key from your Darkibox account"`
+}
+
+var config = driver.Config{
+	Name:        "Darkibox",
+	LocalSort:   false,
+	OnlyLocal:   false,
+	OnlyProxy:   true,
+	NoCache:     false,
+	NoUpload:    false,
+	DefaultRoot: "0",
+}
+
+func init() {
+	op.RegisterDriver(func() driver.Driver {
+		return &Darkibox{}
+	})
+}

--- a/drivers/darkibox/types.go
+++ b/drivers/darkibox/types.go
@@ -1,0 +1,79 @@
+package darkibox
+
+import "encoding/json"
+
+// apiResponse is the common wrapper for all Darkibox API responses.
+type apiResponse struct {
+	Msg       string          `json:"msg"`
+	Result    json.RawMessage `json:"result"`
+	ServerTime string         `json:"server_time"`
+	Status     int            `json:"status"`
+}
+
+// accountInfoResult represents the result of /api/account/info
+type accountInfoResult struct {
+	Email       string `json:"email"`
+	Balance     string `json:"balance"`
+	StorageUsed string `json:"storage_used"`
+}
+
+// fileListResult represents the result of /api/file/list
+type fileListResult struct {
+	Results      int        `json:"results"`
+	ResultsTotal int        `json:"results_total"`
+	Files        []fileItem `json:"files"`
+}
+
+type fileItem struct {
+	FileCode string `json:"file_code"`
+	Name     string `json:"name"`
+	Title    string `json:"title"`
+	Size     int64  `json:"size"`
+	Uploaded string `json:"uploaded"`
+	FldID    int64  `json:"fld_id"`
+}
+
+// folderListResult represents the result of /api/folder/list
+type folderListResult struct {
+	Folders []folderItem `json:"folders"`
+}
+
+type folderItem struct {
+	FldID int64  `json:"fld_id"`
+	Name  string `json:"name"`
+	Code  string `json:"code"`
+}
+
+// directLinkResult represents the result of /api/file/direct_link
+type directLinkResult struct {
+	Versions []directLinkVersion `json:"versions"`
+}
+
+type directLinkVersion struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// uploadServerResult represents the result of /api/upload/server
+type uploadServerResult struct {
+	URL string `json:"url"`
+}
+
+// uploadResult represents the response from the upload endpoint
+type uploadResult struct {
+	Files []uploadedFile `json:"files"`
+}
+
+type uploadedFile struct {
+	FileCode string `json:"filecode"`
+	URL      string `json:"url"`
+	Name     string `json:"name"`
+	Size     int64  `json:"size"`
+	Status   int    `json:"status"`
+}
+
+// folderCreateResult represents the result of /api/folder/create
+type folderCreateResult struct {
+	FldID int64  `json:"fld_id"`
+	Name  string `json:"name"`
+}

--- a/drivers/darkibox/util.go
+++ b/drivers/darkibox/util.go
@@ -1,0 +1,88 @@
+package darkibox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/alist-org/alist/v3/drivers/base"
+)
+
+const apiBase = "https://darkibox.com/api"
+
+// callAPI makes a GET request to the Darkibox API with the given endpoint and params.
+// It automatically injects the API key. The result JSON is unmarshalled into out if non-nil.
+func (d *Darkibox) callAPI(ctx context.Context, endpoint string, params map[string]string, out any) error {
+	query := map[string]string{
+		"key": d.APIKey,
+	}
+	for k, v := range params {
+		if strings.TrimSpace(v) == "" {
+			continue
+		}
+		query[k] = v
+	}
+
+	var resp apiResponse
+	r, err := base.RestyClient.R().
+		SetContext(ctx).
+		SetQueryParams(query).
+		SetResult(&resp).
+		Get(apiBase + endpoint)
+	if err != nil {
+		return err
+	}
+	if r.StatusCode() != http.StatusOK {
+		return fmt.Errorf("darkibox http error: %d", r.StatusCode())
+	}
+	if resp.Status != 200 {
+		return fmt.Errorf("darkibox api error: status=%d msg=%s", resp.Status, resp.Msg)
+	}
+	if out == nil || len(resp.Result) == 0 || string(resp.Result) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(resp.Result, out); err != nil {
+		return fmt.Errorf("decode darkibox result failed: %w", err)
+	}
+	return nil
+}
+
+// fldIDStr converts a folder ID (which may be the root "0") to a string suitable for API params.
+func fldIDStr(id string) string {
+	if id == "" {
+		return "0"
+	}
+	return id
+}
+
+// encodeFolderID prefixes a folder ID so we can distinguish folders from files.
+func encodeFolderID(id int64) string {
+	return "d:" + strconv.FormatInt(id, 10)
+}
+
+// encodeFileID prefixes a file code so we can distinguish files from folders.
+func encodeFileID(code string) string {
+	return "f:" + code
+}
+
+// folderIDFromObjID extracts the numeric folder ID string from an object ID.
+func folderIDFromObjID(id string) string {
+	if strings.HasPrefix(id, "d:") {
+		return strings.TrimPrefix(id, "d:")
+	}
+	if id == "" || id == "/" {
+		return "0"
+	}
+	return id
+}
+
+// fileCodeFromObjID extracts the file code from an object ID.
+func fileCodeFromObjID(id string) string {
+	if strings.HasPrefix(id, "f:") {
+		return strings.TrimPrefix(id, "f:")
+	}
+	return id
+}


### PR DESCRIPTION
## Summary
- Add driver for [Darkibox](https://darkibox.com/), an XFileSharing-based video hosting platform
- Uses the REST API ([docs](https://darkibox.com/api.html)) for all operations
- Authentication via API key

Closes #8079

## Supported operations
| Operation | API endpoint | Status |
|---|---|---|
| List files | `/api/file/list` (paginated) | Implemented |
| List folders | `/api/folder/list` | Implemented |
| Upload | `/api/upload/server` + multipart POST | Implemented |
| Download | `/api/file/direct_link` | Implemented |
| Delete file | `/api/file/delete` | Implemented |
| Delete folder | `/api/folder/delete` | Implemented |
| Create folder | `/api/folder/create` | Implemented |
| Move file | `/api/file/move` | Implemented |

## Files
- `drivers/darkibox/driver.go` - Main driver (List, Link, MakeDir, Remove, Move, Put)
- `drivers/darkibox/meta.go` - Config and registration
- `drivers/darkibox/types.go` - API response types
- `drivers/darkibox/util.go` - API client helpers
- `drivers/all.go` - Driver registration

## Implementation notes
- Handles API quirks: folder IDs as int (not string), different field names between endpoints
- Direct link API uses `"versions"` array with quality names ("o"=original preferred)
- Upload uses two-step process: get upload server URL, then POST multipart form
- Progress tracking for uploads via `driver.NewLimitedUploadStream`

